### PR TITLE
Make download actually work

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,8 @@ class consul::install {
       url       => $consul::download_url,
       target    => $consul::bin_dir,
       extension => 'zip',
+      checksum  => false,
+      follow_redirects => true,
     }
 
   } elsif $consul::install_method == 'package' {


### PR DESCRIPTION
there is no .md5 file to download so checksum should be false
Also they use a cdn which redirects....

And thats not all: archive needs this patch: https://github.com/curator/puppet-archive/commit/58facc8c599042d2fbdb2c2e244d93b0184fe7cb
