### PR TITLE
Convert from setuid/setgid to sudo for Lucid support. Allow for group management.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,8 @@
 class consul (
   $manage_user    = true,
   $user           = 'consul',
+  $manage_group   = true,
+  $group          = 'consul',
   $bin_dir        = '/usr/local/bin',
   $arch           = $consul::params::arch,
   $version        = $consul::params::version,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,5 +40,9 @@ class consul::install {
       ensure => 'present',
     }
   }
-
+  if $consul::manage_group {
+    group { $consul::group:
+      ensure => 'present',
+    }
+  }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -45,20 +45,30 @@ describe 'consul' do
     it { should contain_staging__file('consul.zip').with(:source => 'http://myurl') }
   end
 
-  context "By default, a user should be installed" do
+  context "By default, a user and group should be installed" do
     let(:facts) {{ :architecture => 'x86_64' }}
     it { should contain_user('consul').with(:ensure => :present) }
+    it { should contain_group('consul').with(:ensure => :present) }
   end
   context "When asked not to manage the user" do
     let(:facts) {{ :architecture => 'x86_64' }}
     let(:params) {{ :manage_user => false }}
     it { should_not contain_user('consul') }
   end
+  context "When asked not to manage the group" do
+    let(:facts) {{ :architecture => 'x86_64' }}
+    let(:params) {{ :manage_group => false }}
+    it { should_not contain_group('consul') }
+  end
   context "With a custom username" do
     let(:facts) {{ :architecture => 'x86_64' }}
-    let(:params) {{ :user => 'custom_consul_user' }}
+    let(:params) {{
+      :user => 'custom_consul_user',
+      :group => 'custom_consul_group',
+    }}
     it { should contain_user('custom_consul_user').with(:ensure => :present) }
-    it { should contain_file('/etc/init/consul.conf').with_content(/setuid custom_consul_user/) }
+    it { should contain_group('custom_consul_group').with(:ensure => :present) }
+    it { should contain_file('/etc/init/consul.conf').with_content(/sudo -u custom_consul_user -g custom_consul_group/) }
   end
 
   # Config Stuff

--- a/templates/consul.upstart.erb
+++ b/templates/consul.upstart.erb
@@ -6,10 +6,7 @@ stop on runlevel [06]
 env CONSUL=<%= scope.lookupvar('consul::bin_dir') %>/consul
 env CONFIG=<%= scope.lookupvar('consul::config_dir') %>
 
-setuid <%= scope.lookupvar('consul::user') %>
-setgid nobody
-
-exec $CONSUL agent -config-dir $CONFIG
+exec sudo -u <%= scope.lookupvar('consul::user') %> -g <%= scope.lookupvar('consul::group') %> $CONSUL agent -config-dir $CONFIG
 
 respawn
 respawn limit 10 10


### PR DESCRIPTION
Fixes https://github.com/solarkennedy/puppet-consul/issues/5
