### PR TITLE
remove quotes from 'port' value

### DIFF
--- a/templates/service.json.erb
+++ b/templates/service.json.erb
@@ -1,2 +1,5 @@
 <%- require 'json' -%>
+<%- if @service_hash['service']['port']  -%> 
+<%-   @service_hash['service']['port'] = @service_hash['service']['port'].to_i -%> 
+<%- end -%> 
 <%= JSON.pretty_generate(Hash[@service_hash.sort]) %>


### PR DESCRIPTION
I was getting this error until I removed the quotes from port value in the json file:
- 'Port' expected type 'int', got unconvertible type 'string'
  [FAILED]^M==> Error decoding '/etc/consul/service_AAA.json': 1 error(s) decoding:
