### PR TITLE
Added upstart link for old init.d functionality on upstart jobs

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -69,6 +69,13 @@ class consul::install {
         group   => 'root',
         content => template('consul/consul.upstart.erb'),
       }
+      file { '/etc/init.d/consul':
+        ensure => link,
+        target => "/lib/init/upstart-job",
+        owner  => root,
+        group  => root,
+        mode   => 0755,
+      }
     }
     'systemd' : {
       file { '/lib/systemd/system/consul.service':


### PR DESCRIPTION
In upstart distributions it is normally good behaviour to add a link in /etc/init.d pointing to upstart-jobs, this way the upstart job will also behave like an init.d job and will issue a warning saying that this is now upstart
