### PR TITLE
Force bootstrap_expect to integer

### DIFF
--- a/templates/config.json.erb
+++ b/templates/config.json.erb
@@ -1,3 +1,4 @@
 <%- require 'json' -%>
+<%- @config_hash.has_key?("bootstrap_expect") and @config_hash["bootstrap_expect"] = @config_hash["bootstrap_expect"].to_i -%>
 <%- @config_hash.has_key?("protocol") and @config_hash["protocol"] = @config_hash["protocol"].to_i -%>
 <%= JSON.pretty_generate(Hash[@config_hash.sort]) %>


### PR DESCRIPTION
In config.json bootstrap_expect has to emitted as an integer or Consul will fail to start.
