### PR TITLE
fix(config.json.erb): casting bootstrap_expect back to int so it outputs without quotes

### DIFF
--- a/templates/config.json.erb
+++ b/templates/config.json.erb
@@ -1,3 +1,4 @@
 <%- require 'json' -%>
 <%- @config_hash.has_key?("protocol") and @config_hash["protocol"] = @config_hash["protocol"].to_i -%>
+<%- @config_hash.has_key?("bootstrap_expect") and @config_hash["bootstrap_expect"] = @config_hash["bootstrap_expect"].to_i -%>
 <%= JSON.pretty_generate(Hash[@config_hash.sort]) %>


### PR DESCRIPTION
`bootstrap_expect` this was coming through as:

```
"bootstrap_expect": "3",
```

instead of 

```
"bootstrap_expect": 3,
```

and breaking on consul startup
