### PR TITLE
Changed cluster join code

### DIFF
--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -13,9 +13,9 @@ class consul::run_service {
   if $consul::join_cluster {
     exec { 'join consul cluster':
       cwd         => $consul::config_dir,
-      path        => $consul::bin_dir,
+      path        => [$consul::bin_dir,'/bin','/usr/bin'],
       command     => "consul join ${consul::join_cluster}",
-      refreshonly => true,
+      onlyif      => 'consul info | grep -P "num_peers\s*=\s*0"',
       subscribe   => Service['consul'],
     }
   }


### PR DESCRIPTION
Currently if initial server is not up while starting other servers or agent, the
cluster join will be failed, and unless there is any (new) service definition,
that node will not be joining to the consul cluster, until there is a service
restart as cluster join code in the is only called after service restart.
This patch will fix this issue.
