### PR TITLE
Add support for SLES

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -101,6 +101,14 @@ class consul::install {
         content => template('consul/consul.debian.erb')
       }
     }
+    'sles' : {
+      file { '/etc/init.d/consul':
+        mode    => '0555',
+        owner   => 'root',
+        group   => 'root',
+        content => template('consul/consul.sles.erb')
+      }
+    }
     default : {
       fail("I don't know how to create an init script for style $init_style")
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class consul::params {
       default      => 'systemd',
     },
     'Debian'             => 'debian',
+    'SLES'               => 'sles',
     default => undef
   }
 }

--- a/templates/consul.sles.erb
+++ b/templates/consul.sles.erb
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+#       /etc/rc.d/init.d/consul
+#
+#       Daemonize the consul agent.
+#
+### BEGIN INIT INFO
+# Provides:          consul
+# Required-Start:    network
+# Should-Start:      $null
+# Required-Stop:     $null
+# Should-Stop:	     $null
+# Default-Start:     3 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Service discovery and configuration made easy.
+# Description:       Service discovery and configuration made easy.
+### END INIT INFO
+
+. /etc/rc.status
+
+rc_reset
+
+CONSUL_BIN=<%= scope.lookupvar('consul::bin_dir') %>/consul
+CONFIG_DIR=<%= scope.lookupvar('consul::config_dir') %>
+LOG_FILE=/var/log/consul
+
+
+case "$1" in
+    start)
+        echo -n "Starting consul "
+        ## Start daemon with startproc(8). If this fails
+        ## the return value is set appropriately by startproc.
+        startproc $CONSUL_BIN agent -config-dir "$CONFIG_DIR" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE"
+
+        # Remember status and be verbose
+        rc_status -v
+        ;;
+    stop)
+        echo -n "Shutting down consul "
+        ## Stop daemon with killproc(8) and if this fails
+        ## killproc sets the return value according to LSB.
+
+        killproc -TERM $CONSUL_BIN
+
+        # Remember status and be verbose
+        rc_status -v
+        ;;
+    restart)
+        ## Stop the service and regardless of whether it was
+        ## running or not, start it again.
+        $0 stop
+        $0 start
+
+        # Remember status and be quiet
+        rc_status
+        ;;
+    reload)
+        # If it supports signaling:
+        echo -n "Reload service consul "
+        killproc -HUP $CONSUL_BIN
+        #touch /var/run/consul.pid
+        rc_status -v
+
+        ## Otherwise if it does not support reload:
+        #rc_failed 3
+        #rc_status -v
+        ;;
+    status)
+        echo -n "Checking for service consul "
+        ## Check status with checkproc(8), if process is running
+        ## checkproc will return with exit status 0.
+
+        # Return value is slightly different for the status command:
+        # 0 - service up and running
+        # 1 - service dead, but /var/run/  pid  file exists
+        # 2 - service dead, but /var/lock/ lock file exists
+        # 3 - service not running (unused)
+        # 4 - service status unknown :-(
+        # 5--199 reserved (5--99 LSB, 100--149 distro, 150--199 appl.)
+
+        # NOTE: checkproc returns LSB compliant status values.
+        checkproc $CONSUL_BIN
+        # NOTE: rc_status knows that we called this init script with
+        # "status" option and adapts its messages accordingly.
+        rc_status -v
+        ;;
+    *)
+        ## If no parameters are given, print which are avaiable.
+        echo "Usage: $0 {start|stop|status|restart|reload}"
+        exit 1
+        ;;
+esac
+
+rc_exit


### PR DESCRIPTION
**Description**

Created an `init.d` script for managing the Consul service on SLES. Adapted from the example at: https://www.novell.com/coolsolutions/feature/15380.html

**Testing Done**
- Provisioned with Puppet in a Vagrant box of SLES 11 SP3
- Saw that the Consul service was started
- Rebooted the VM; Saw that the Consul service came up automatically
- Verified log content in `/var/log/consul`
- Manually tested the "start", "stop", "restart" functions of the init script and verified correct behavior
- Verified via log file that the SIGHUP from "reload" gets received by the consul daemon

**Relevant output:**

```
vagrant@sles:/var/log> cat /var/log/consul
==> WARNING: It is highly recommended to set GOMAXPROCS higher than 1
==> Starting Consul agent...
==> Starting Consul agent RPC...
==> Consul agent running!
         Node name: 'foobar'
        Datacenter: 'sjc'
            Server: true (bootstrap: false)
       Client Addr: 127.0.0.1 (HTTP: 8500, DNS: 8600, RPC: 8400)
      Cluster Addr: 10.0.2.15 (LAN: 8301, WAN: 8302)
    Gossip encrypt: false, RPC-TLS: false, TLS-Incoming: false

==> Log data will now stream in as it occurs:

    2014/10/15 14:35:06 [INFO] serf: EventMemberJoin: foobar 10.0.2.15
    2014/10/15 14:35:06 [INFO] serf: EventMemberJoin: foobar.sjc 10.0.2.15
    2014/10/15 14:35:06 [INFO] raft: Node at 10.0.2.15:8300 [Follower] entering Follower state
    2014/10/15 14:35:06 [WARN] serf: Failed to re-join any previously known node

sles:/var/log # sudo /etc/init.d/consul stop
Shutting down consul                                                                                                                           done

sles:/var/log # sudo /etc/init.d/consul status
Checking for service consul                                                                                                                    unused

sles:/var/log # sudo /etc/init.d/consul start
Starting consul                                                                                                                                done

sles:/var/log # sudo /etc/init.d/consul status
Checking for service consul                                                                                                                    running

sles:/var/log # sudo /etc/init.d/consul reload
Reload service consul                                                                                                                          done
```
