### PR TITLE
Version bump; Download Consul 0.4.0

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class consul::params {
   $package_ensure    = 'latest'
   $ui_package_name   = 'consul_ui'
   $ui_package_ensure = 'latest'
-  $version = '0.3.1'
+  $version = '0.4.0'
 
   case $::architecture {
     'x86_64', 'amd64': { $arch = 'amd64' }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -64,7 +64,7 @@ describe 'consul' do
   end
 
   context "When installing via URL by default" do
-    it { should contain_staging__file('consul.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.3.1_linux_amd64.zip') }
+    it { should contain_staging__file('consul.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.4.0_linux_amd64.zip') }
   end
 
   context "When installing via URL by with a special version" do
@@ -109,7 +109,7 @@ describe 'consul' do
         'ui_dir'   => '/dir1/dir2',
       },
     }}
-    it { should contain_staging__file('consul_web_ui.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.3.1_web_ui.zip') }
+    it { should contain_staging__file('consul_web_ui.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.4.0_web_ui.zip') }
   end
 
   context "When installing UI via URL by with a special version" do


### PR DESCRIPTION
New Consul 0.4.0 was released last month. Might as well install 0.4.0 by default instead of 0.3.1.

Changelog: https://github.com/hashicorp/consul/blob/master/CHANGELOG.md#040-september-5-2014
