### PR TITLE
Add join_wan feature

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,7 @@ class consul (
   $purge_config_dir  = true,
   $group             = 'consul',
   $join_cluster      = false,
+  $join_wan          = false,
   $bin_dir           = '/usr/local/bin',
   $arch              = $consul::params::arch,
   $version           = $consul::params::version,

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -20,4 +20,14 @@ class consul::run_service {
     }
   }
 
+  if $consul::join_wan {
+    exec { 'join consul wan':
+      cwd         => $consul::config_dir,
+      path        => [$consul::bin_dir,'/bin','/usr/bin'],
+      command     => "consul join -wan ${consul::join_wan}",
+      onlyif      => "consul members -wan -detailed | grep -vP \"dc=${consul::config_hash['datacenter']}\" | grep -P 'alive'",
+      subscribe   => Service['consul'],
+    }
+  }
+
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,6 +47,17 @@ describe 'consul' do
     it { should_not contain_exec('join consul cluster') }
   end
 
+  context 'When joining consul to a wan cluster by a known URL' do
+    let(:params) {{
+        :join_wan => 'wan_host.test.com'
+    }}
+    it { should contain_exec('join consul wan').with(:command => 'consul join -wan wan_host.test.com') }
+  end
+
+  context 'By default, should not attempt to join a wan cluster' do
+    it { should_not contain_exec('join consul wan') }
+  end
+
   context 'When requesting to install via a package with defaults' do
     let(:params) {{
       :install_method => 'package'


### PR DESCRIPTION
Allow the module to join a node to a wan cluster/a multiple datacenter set up.

The grep is a bit complex but it was the cleanest way I could find to determine if the node was a wan member.
