### PR TITLE
Add sysconfig support for sysv

### DIFF
--- a/templates/consul.sysv.erb
+++ b/templates/consul.sysv.erb
@@ -18,6 +18,10 @@ CONFIG=<%= scope.lookupvar('consul::config_dir') %>
 PID_FILE=/var/run/consul/pidfile
 LOG_FILE=/var/log/consul
 
+[ -e /etc/sysconfig/consul ] && . /etc/sysconfig/consul
+
+export GOMAXPROCS=${GOMAXPROCS:-2}
+
 start() {
         echo -n "Starting consul: "
         daemon --user=<%= scope.lookupvar('consul::user') %> \


### PR DESCRIPTION
Source `/etc/sysconfig/consul`, if present. This will allow users to override `PID_FILE` or `LOG_FILE` if they wish. Also, it will allow setting GOMAXPROCS. This is maybe the most important feature this provides because otherwise GOMAXPROCS defaults to 1, which is not recommended. If the user does not set GOMAXPROCS after this change, it will default to 2.

I don't believe managing `/etc/sysconfig/consul` is necessary within this module. It's not a required file for this to work and users can optionally manage that file in a profile or wrapper module.
