### PR TITLE
Set default of GOMAXPROCS=2 for SLES

### DIFF
--- a/templates/consul.sles.erb
+++ b/templates/consul.sles.erb
@@ -25,6 +25,12 @@ CONFIG_DIR=<%= scope.lookupvar('consul::config_dir') %>
 LOG_FILE=/var/log/consul
 
 
+# read settings like GOMAXPROCS from "/etc/sysconfig/consul"
+[ -e /etc/sysconfig/consul ] && . /etc/sysconfig/consul
+
+export GOMAXPROCS=${GOMAXPROCS:-2}
+
+
 case "$1" in
     start)
         echo -n "Starting consul "


### PR DESCRIPTION
- Update the SLES init script to set the default for GOMAXPROCS=2
- Read settings from "/etc/sysconfig/consul"
