### PR TITLE
Modify "join_cluster" to key off of "known_servers". Fixes #31.

### DIFF
--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -15,7 +15,7 @@ class consul::run_service {
       cwd         => $consul::config_dir,
       path        => [$consul::bin_dir,'/bin','/usr/bin'],
       command     => "consul join ${consul::join_cluster}",
-      onlyif      => 'consul info | grep -P "num_peers\s*=\s*0"',
+      onlyif      => 'consul info | grep "known_servers = 0"',
       subscribe   => Service['consul'],
     }
   }


### PR DESCRIPTION
The existing implementation of `join_cluster` relies upon `num_peers`, which doesn't exist anymore. Modify `join_cluster` to use `known_servers` instead.

I tested this with a set of 3 Vagrant boxes running puppet. Before `join_cluster` runs, I see:

```
$ consul info | grep known
  known_servers = 0
```

And after `join_cluster` runs I see:

```
$ consul info | grep known
known_servers = 1

$ consul members
Node               Address               Status  Type    Build  Protocol
vi-cobbler11       192.168.181.146:8301  alive   client  0.4.1  2
vi-devops-consul9  192.168.181.142:8301  alive   server  0.4.1  2
vi-cobbler10       192.168.181.129:8301  alive   client  0.4.1  2
```