### PR TITLE
Consul reload

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -50,5 +50,5 @@ define consul::check(
   File[$consul::config_dir] ->
   file { "${consul::config_dir}/check_${id}.json":
     content => template('consul/check.json.erb'),
-  } ~> Class['consul::run_service']
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,4 +85,8 @@ class consul (
   class { 'consul::run_service': } ->
   Class['consul']
 
+  include consul::reload
+  Consul::Watch <| |> ~> Class['consul::reload']
+  Consul::Check <| |> ~> Class['consul::reload']
+  Consul::Service <| |> ~> Class['consul::reload']
 }

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -1,0 +1,13 @@
+# == Class consul::reload
+#
+# This class is meant to be called from consul
+# It will execute `consul reload`, useful for if a config file has changed.
+#
+class consul::reload {
+  exec { 'consul reload':
+    cwd         => $consul::config_dir,
+    path        => [$consul::bin_dir, '/bin', '/usr/bin'],
+    command     => 'consul reload',
+    refreshonly => true,
+  }
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -58,5 +58,5 @@ define consul::service(
   File[$consul::config_dir] ->
   file { "${consul::config_dir}/service_${id}.json":
     content => template('consul/service.json.erb'),
-  } ~> Class['consul::run_service']
+  }
 }

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -88,5 +88,5 @@ define consul::watch(
   File[$consul::config_dir] ->
   file { "${consul::config_dir}/watch_${id}.json":
     content => template('consul/watch.json.erb'),
-  } ~> Class['consul::run_service']
+  }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -273,6 +273,13 @@ describe 'consul' do
     }}
     it { should contain_file('/etc/init/consul.conf').with_content(/\$CONSUL agent .*-some-extra-argument$/) }
   end
+
   # Service Stuff
+  context "After successful init" do
+    it {
+      should contain_service('consul')
+      should contain_class('consul::reload')
+    }
+  end
 
 end

--- a/spec/classes/reload_spec.rb
+++ b/spec/classes/reload_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'consul::reload' do
+  it {
+    should contain_exec('consul reload') \
+      .with_command('consul reload')
+      .with_refreshonly(true)
+  }
+end


### PR DESCRIPTION
Adds a `consul::reload` resource and notifies it when any config file changes, rather than restarting the whole service.

Should alleviate the side-effects of #45.