### PR TITLE
Include config_hash in consul::config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,7 +3,8 @@
 # This class is called from consul
 #
 class consul::config(
-  $purge = true
+  $purge       = true,
+  $config_hash = $consul::config_hash, 
 ) {
 
   file { $consul::config_dir:


### PR DESCRIPTION
The template `consul/config.json.erb` references to `@config_hash`, but this variable does not exist in the scope where it is declared. This commit adds a local variable, `$config_hash`, to the scope of `Class['consul::config']`.
