### PR TITLE
Make init_style can be disabled

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -61,58 +61,62 @@ class consul::install {
     fail("The provided install method ${consul::install_method} is invalid")
   }
 
-  case $consul::init_style {
-    'upstart' : {
-      file { '/etc/init/consul.conf':
-        mode   => '0444',
-        owner   => 'root',
-        group   => 'root',
-        content => template('consul/consul.upstart.erb'),
+  if $consul::init_style {
+
+    case $consul::init_style {
+      'upstart' : {
+        file { '/etc/init/consul.conf':
+          mode   => '0444',
+          owner   => 'root',
+          group   => 'root',
+          content => template('consul/consul.upstart.erb'),
+        }
+        file { '/etc/init.d/consul':
+          ensure => link,
+          target => "/lib/init/upstart-job",
+          owner  => root,
+          group  => root,
+          mode   => 0755,
+        }
       }
-      file { '/etc/init.d/consul':
-        ensure => link,
-        target => "/lib/init/upstart-job",
-        owner  => root,
-        group  => root,
-        mode   => 0755,
+      'systemd' : {
+        file { '/lib/systemd/system/consul.service':
+          mode   => '0644',
+          owner   => 'root',
+          group   => 'root',
+          content => template('consul/consul.systemd.erb'),
+        }
       }
-    }
-    'systemd' : {
-      file { '/lib/systemd/system/consul.service':
-        mode   => '0644',
-        owner   => 'root',
-        group   => 'root',
-        content => template('consul/consul.systemd.erb'),
+      'sysv' : {
+        file { '/etc/init.d/consul':
+          mode    => '0555',
+          owner   => 'root',
+          group   => 'root',
+          content => template('consul/consul.sysv.erb')
+        }
       }
-    }
-    'sysv' : {
-      file { '/etc/init.d/consul':
-        mode    => '0555',
-        owner   => 'root',
-        group   => 'root',
-        content => template('consul/consul.sysv.erb')
+      'debian' : {
+        file { '/etc/init.d/consul':
+          mode    => '0555',
+          owner   => 'root',
+          group   => 'root',
+          content => template('consul/consul.debian.erb')
+        }
       }
-    }
-    'debian' : {
-      file { '/etc/init.d/consul':
-        mode    => '0555',
-        owner   => 'root',
-        group   => 'root',
-        content => template('consul/consul.debian.erb')
+      'sles' : {
+        file { '/etc/init.d/consul':
+          mode    => '0555',
+          owner   => 'root',
+          group   => 'root',
+          content => template('consul/consul.sles.erb')
+        }
       }
-    }
-    'sles' : {
-      file { '/etc/init.d/consul':
-        mode    => '0555',
-        owner   => 'root',
-        group   => 'root',
-        content => template('consul/consul.sles.erb')
+      default : {
+        fail("I don't know how to create an init script for style $init_style")
       }
-    }
-    default : {
-      fail("I don't know how to create an init script for style $init_style")
     }
   }
+
 
   if $consul::manage_user {
     user { $consul::user:

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -257,6 +257,13 @@ describe 'consul' do
     }
   end
 
+  context "When asked not to manage the init_style" do
+    let(:params) {{ :init_style => false }}
+    it { should contain_class('consul').with_init_style(false) }
+    it { should_not contain_file("/etc/init.d/consul") }
+    it { should_not contain_file("/lib/systemd/system/consul.service") }
+  end
+
   context "On squeeze" do
     let(:facts) {{
       :operatingsystem => 'Debian',


### PR DESCRIPTION
In case install consul from package, the start up script will be
included in the packaging system. Give an option to disable the
init_style so that user can leverage the start script from package.
