### PR TITLE
Add config_defaults hash parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ class consul (
   $config_dir        = '/etc/consul',
   $extra_options     = '',
   $config_hash       = {},
+  $config_defaults   = {},
   $service_enable    = true,
   $service_ensure    = 'running',
   $init_style        = $consul::params::init_style,
@@ -65,13 +66,17 @@ class consul (
   validate_bool($purge_config_dir)
   validate_bool($manage_user)
   validate_hash($config_hash)
+  validate_hash($config_defaults)
 
-  if $config_hash['data_dir'] {
-    $data_dir = $config_hash['data_dir']
+  $_config_hash = merge($config_defaults, $config_hash)
+  validate_hash($_config_hash)
+
+  if $_config_hash['data_dir'] {
+    $data_dir = $_config_hash['data_dir']
   }
 
-  if $config_hash['ui_dir'] {
-    $ui_dir = $config_hash['ui_dir']
+  if $_config_hash['ui_dir'] {
+    $ui_dir = $_config_hash['ui_dir']
   }
 
   if ($ui_dir and ! $data_dir) {

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -25,7 +25,7 @@ class consul::run_service {
       cwd         => $consul::config_dir,
       path        => [$consul::bin_dir,'/bin','/usr/bin'],
       command     => "consul join -wan ${consul::join_wan}",
-      onlyif      => "consul members -wan -detailed | grep -vP \"dc=${consul::config_hash['datacenter']}\" | grep -P 'alive'",
+      onlyif      => "consul members -wan -detailed | grep -vP \"dc=${consul::_config_hash['datacenter']}\" | grep -P 'alive'",
       subscribe   => Service['consul'],
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -192,6 +192,35 @@ describe 'consul' do
     it { should_not contain_file('config.json').with_content(/"bootstrap_expect": "5"/) }
   end
 
+  context 'Config_defaults is used to provide additional config' do
+    let(:params) {{
+      :config_defaults => {
+          'data_dir' => '/dir1',
+      },
+      :config_hash => {
+          'bootstrap_expect' => '5',
+      }
+    }}
+    it { should contain_file('config.json').with_content(/"bootstrap_expect": 5/) }
+    it { should contain_file('config.json').with_content(/"data_dir": "\/dir1"/) }
+  end
+
+  context 'Config_defaults is used to provide additional config and is overridden' do
+    let(:params) {{
+      :config_defaults => {
+          'data_dir' => '/dir1',
+          'server' => false,
+      },
+      :config_hash => {
+          'bootstrap_expect' => '5',
+          'server' => true,
+      }
+    }}
+    it { should contain_file('config.json').with_content(/"bootstrap_expect": 5/) }
+    it { should contain_file('config.json').with_content(/"data_dir": "\/dir1"/) }
+    it { should contain_file('config.json').with_content(/"server": true/) }
+  end
+
   context "When asked not to manage the user" do
     let(:params) {{ :manage_user => false }}
     it { should_not contain_user('consul') }

--- a/templates/config.json.erb
+++ b/templates/config.json.erb
@@ -1,4 +1,4 @@
 <%- require 'json' -%>
-<%- @config_hash.has_key?("protocol") and @config_hash["protocol"] = @config_hash["protocol"].to_i -%>
-<%- @config_hash.has_key?("bootstrap_expect") and @config_hash["bootstrap_expect"] = @config_hash["bootstrap_expect"].to_i -%>
-<%= JSON.pretty_generate(Hash[@config_hash.sort]) %>
+<%- @_config_hash.has_key?("protocol") and @_config_hash["protocol"] = @_config_hash["protocol"].to_i -%>
+<%- @_config_hash.has_key?("bootstrap_expect") and @_config_hash["bootstrap_expect"] = @_config_hash["bootstrap_expect"].to_i -%>
+<%= JSON.pretty_generate(Hash[@_config_hash.sort]) %>


### PR DESCRIPTION
Allow sites to specify a baseline set of config items to be applied to
all nodes via config_defaults that can be overridden via hash
merge with config_hash. This doesn't change the current behavior
for users, but allows users running both agents and servers
to consolidate defaults for both roles in a single key instead
of repeating the defaults merely to change a small number of config
options such as server: true and bootstrap_expect on server nodes.
