### PR TITLE
Allow hash keys to be set to undef

### DIFF
--- a/lib/puppet/parser/functions/consul_sorted_json.rb
+++ b/lib/puppet/parser/functions/consul_sorted_json.rb
@@ -34,8 +34,7 @@ Would return: {'key':'value'}
   ) do |arguments|
     raise(Puppet::ParseError, "sorted_json(): Wrong number of arguments " +
       "given (#{arguments.size} for 1)") if arguments.size != 1
-
-    json = arguments[0]
+    json = arguments[0].delete_if {|key, value| value == :undef }
     return sorted_json(json)
   end
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,7 +7,7 @@ class consul::config(
   $purge = true,
 ) {
 
-  # implicit conversion from string to int so it won't be quoted in JSON 
+  # implicit conversion from string to int so it won't be quoted in JSON
   if has_key($config_hash, 'protocol') {
     $protocol_hash = {
       protocol => $config_hash['protocol'] * 1
@@ -16,7 +16,7 @@ class consul::config(
     $protocol_hash = {}
   }
 
-  # implicit conversion from string to int so it won't be quoted in JSON 
+  # implicit conversion from string to int so it won't be quoted in JSON
   if has_key($config_hash, 'bootstrap_expect') {
     $bootstrap_expect_hash = {
       'bootstrap_expect' => $config_hash['bootstrap_expect'] * 1

--- a/spec/functions/consul_sorted_json_spec.rb
+++ b/spec/functions/consul_sorted_json_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe 'consul_sorted_json' do
+  it { should run.with_params({'foo' => :undef}).and_return("{}") }
+  it { should run.with_params({'b' => 1, 'a' => 2, 'c' => 3}).and_return('{"a":2,"b":1,"c":3}')}
+end


### PR DESCRIPTION
This patch protects against the case where
hash values happen to be set to :undef (Puppet's
nilish representation). Previously, having nil
values set to null caused a stack trace, now,
with this patch, those hash values are simply
dropped.

It also gets rid of some trailing white-spaces