### PR TITLE
Add class to secure local ports

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     staging: "https://github.com/nanliu/puppet-staging.git"
+    firewall: "git://github.com/puppetlabs/puppetlabs-firewall"
   symlinks:
     consul: "#{source_dir}"

--- a/Modulefile
+++ b/Modulefile
@@ -9,3 +9,4 @@ project_page  'https://github.com/solarkennedy/puppet-consul'
 
 dependency 'puppetlabs/stdlib', '>= 0.1.6'
 dependency 'nanliu/staging', '>=0.4.0'
+dependency 'puppetlabs/firewall', '>=1.3.0'

--- a/manifests/secure_local_ports.pp
+++ b/manifests/secure_local_ports.pp
@@ -1,0 +1,27 @@
+#
+# Secures consul usage by ensuring that only the
+# specified users can access internal consul services
+# by default
+#
+class consul::secure_local_ports(
+  $internal_ports = ['8300', '8400', '8500'],
+  $consul_user    = 'consul'
+) {
+  include "firewall"
+  Firewall {
+    chain       => 'OUTPUT',
+    action      => 'accept',
+    destination => '127.0.0.1',
+    proto       => 'tcp',
+    dport       => ['8300', '8400', '8500'],
+  }
+  firewall { '001consul_allow_root':
+    uid         => '0',
+  }
+  firewall { '002consul_allow_consul':
+    uid         => $consul_user,
+  }
+  firewall { '999consul_drop':
+    action => 'drop',
+  }
+}

--- a/spec/classes/secure_local_ports_spec.rb
+++ b/spec/classes/secure_local_ports_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'consul::secure_local_ports' do
+
+  context 'with defaults' do
+
+    it 'should contain default resources' do
+      should contain_firewall('001consul_allow_root').with({
+        'chain'       => 'OUTPUT',
+        'action'      => 'accept',
+        'destination' => '127.0.0.1',
+        'proto'       => 'tcp',
+        'dport'       => ['8300', '8400', '8500'],
+        'uid'         => '0',
+      })
+      should contain_firewall('002consul_allow_consul').with({
+        'chain'       => 'OUTPUT',
+        'action'      => 'accept',
+        'destination' => '127.0.0.1',
+        'proto'       => 'tcp',
+        'dport'       => ['8300', '8400', '8500'],
+        'uid'         => 'consul',
+      })
+      should contain_firewall('999consul_drop').with({
+        'chain'       => 'OUTPUT',
+        'action'      => 'drop',
+        'destination' => '127.0.0.1',
+        'proto'       => 'tcp',
+        'dport'       => ['8300', '8400', '8500'],
+
+      })
+    end
+  end
+end


### PR DESCRIPTION
While consul does some things great,
by default, it introduces some fairly
severe security risks.

Some of its functionality allows commands
to be run from other machines (exec, service
checks). Since these commands are run behind
services bound to a port on localhost, it means
that by default, any user on a system registered with
consul can execute code on any other registered system.

This patch adds a class that configures firewall rules
to limit access to only root and consul user to interact
with the API.

Unfortunatly, the uid feature for the firewall module does
not work as documented. I am working on the following
upstream patch to resolve the issue:

  https://github.com/puppetlabs/puppetlabs-firewall/pull/466

It probably makes sense to hold off merging this until that
upstream patch is merged and released, but I wanted to go ahead
and put this patch out there becuase:

1. as a reference point, anyone running consul in prod should be
adding these rules
2. to start a conversation to ensure the patch is acceptable as-is
while I work with upstream on the other patch.