### PR TITLE
Adding "status" to the debian init script

### DIFF
--- a/templates/consul.debian.erb
+++ b/templates/consul.debian.erb
@@ -157,9 +157,12 @@ case "$1" in
         ;;
     esac
     ;;
+  status)
+      status_of_proc $DAEMON $NAME && exit 0 || exit $?
+      ;;
   *)
     #echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
-    echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload}" >&2
+    echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
     exit 3
     ;;
 esac


### PR DESCRIPTION
This adds a status argument to the debian init script. Without the status, I experienced puppet continually trying to start consul, even though it was already running.

Thanks for the great module!