### PR TITLE
Support for Amazon OS

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class consul::params {
     'Debian'             => 'debian',
     'SLES'               => 'sles',
     'Darwin'             => 'launchd',
+    'Amazon'             => 'sysv',
     default => undef
   }
   if $init_style == undef {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -254,6 +254,16 @@ describe 'consul' do
     it { should contain_file('/etc/init.d/consul').with_content(/daemon --user=consul/) }
   end
 
+  context "On an Amazon based OS" do
+    let(:facts) {{
+      :operatingsystem => 'Amazon',
+      :operatingsystemrelease => '3.10.34-37.137.amzn1.x86_64'
+    }}
+
+    it { should contain_class('consul').with_init_style('sysv') }
+    it { should contain_file('/etc/init.d/consul').with_content(/daemon --user=consul/) }
+  end
+
   context "On a redhat 7 based OS" do
     let(:facts) {{
       :operatingsystem => 'CentOS',


### PR DESCRIPTION
Tried using this module on EC2 and it failed to start. Looks as though it is because it didn't detect the O/S and so didn't create an init script.

/cc @telent