### PR TITLE
Fix Puppet 3.7.3 giving evaluation error in run_service.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,15 +69,15 @@ class consul (
   validate_hash($config_hash)
   validate_hash($config_defaults)
 
-  $_config_hash = merge($config_defaults, $config_hash)
-  validate_hash($_config_hash)
+  $config_hash_real = merge($config_defaults, $config_hash)
+  validate_hash($config_hash_real)
 
-  if $_config_hash['data_dir'] {
-    $data_dir = $_config_hash['data_dir']
+  if $config_hash_real['data_dir'] {
+    $data_dir = $config_hash_real['data_dir']
   }
 
-  if $_config_hash['ui_dir'] {
-    $ui_dir = $_config_hash['ui_dir']
+  if $config_hash_real['ui_dir'] {
+    $ui_dir = $config_hash_real['ui_dir']
   }
 
   if ($ui_dir and ! $data_dir) {
@@ -86,7 +86,7 @@ class consul (
 
   class { 'consul::install': } ->
   class { 'consul::config':
-    config_hash => $_config_hash,
+    config_hash => $config_hash_real,
     purge       => $purge_config_dir,
   } ~>
   class { 'consul::run_service': } ->

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -29,7 +29,7 @@ class consul::run_service {
       cwd         => $consul::config_dir,
       path        => [$consul::bin_dir,'/bin','/usr/bin'],
       command     => "consul join -wan ${consul::join_wan}",
-      onlyif      => "consul members -wan -detailed | grep -vP \"dc=${consul::_config_hash['datacenter']}\" | grep -P 'alive'",
+      onlyif      => "consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'",
       subscribe   => Service['consul'],
     }
   }


### PR DESCRIPTION
If I run this module out on a CentOS 6.5 box with Puppet 3.7.3 using future parser I get the following error - 

Error: Evaluation Error: Error while evaluating a Resource Statement, Illegal fully qualified name in file /etc/puppet/modules-extra/consul/manifests/run_service.pp at line 32

This looks like some scoping issue because it cannot lookup the variable $_config_hash. This seems to be down to the fact it starts with an underscore. If I change the variable to use $config_hash_real (no underscore) it seems to work out just fine.

This might actually be down to some bug in Puppet itself, I couldn't see anything in the docs (for Puppet) about variable names and scoping, apart from the fact you can no longer have variables that start with a capital letter.

This should circumvent the issue, but might be worth raising an issue on the Puppet project separately too as this seems a bit weird to me?