### PR TITLE
Add support for providing watches/checks/services via hiera 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,12 +62,18 @@ class consul (
   $service_enable    = true,
   $service_ensure    = 'running',
   $init_style        = $consul::params::init_style,
+  $services          = {},
+  $watches           = {},
+  $checks            = {},
 ) inherits consul::params {
 
   validate_bool($purge_config_dir)
   validate_bool($manage_user)
   validate_hash($config_hash)
   validate_hash($config_defaults)
+  validate_hash($services)
+  validate_hash($watches)
+  validate_hash($checks)
 
   $_config_hash = merge($config_defaults, $config_hash)
   validate_hash($_config_hash)
@@ -82,6 +88,18 @@ class consul (
 
   if ($ui_dir and ! $data_dir) {
     warning('data_dir must be set to install consul web ui')
+  }
+
+  if $services {
+    create_resources(consul::service, $services)
+  }
+
+  if $watches {
+    create_resources(consul::watch, $watches)
+  }
+
+  if $checks {
+    create_resources(consul::check, $checks)
   }
 
   class { 'consul::install': } ->

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -266,6 +266,7 @@ describe 'consul' do
     }}
 
     it { should contain_consul__watch('test_watch1').with_type('nodes') }
+    it { should contain_consul__watch('test_watch1').with_handler('test.sh') }
     it { should have_consul__watch_resource_count(1) }
   end
 
@@ -280,6 +281,7 @@ describe 'consul' do
     }}
 
     it { should contain_consul__check('test_check1').with_interval('30') }
+    it { should contain_consul__check('test_check1').with_script('test.sh') }
     it { should have_consul__check_resource_count(1) }
   end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -242,6 +242,47 @@ describe 'consul' do
     it { should contain_file('/etc/init/consul.conf').with_content(/sudo -u custom_consul_user -g custom_consul_group/) }
   end
 
+  context "When the user provides a hash of services" do
+    let (:params) {{
+      :services => {
+        'test_service1' => {
+          'port' => '5'
+        }
+      }
+    }}
+
+    it { should contain_consul__service('test_service1').with_port('5') }
+    it { should have_consul__service_resource_count(1) }
+  end
+
+  context "When the user provides a hash of watches" do
+    let (:params) {{
+      :watches => {
+        'test_watch1' => {
+           'type'    => 'nodes',
+           'handler' => 'test.sh',
+        }
+      }
+    }}
+
+    it { should contain_consul__watch('test_watch1').with_type('nodes') }
+    it { should have_consul__watch_resource_count(1) }
+  end
+
+  context "When the user provides a hash of watches" do
+    let (:params) {{
+      :checks => {
+        'test_check1' => {
+          'interval' => '30',
+          'script'   => 'test.sh',
+        }
+      }
+    }}
+
+    it { should contain_consul__check('test_check1').with_interval('30') }
+    it { should have_consul__check_resource_count(1) }
+  end
+
   context "On a redhat 6 based OS" do
     let(:facts) {{
       :operatingsystem => 'CentOS',


### PR DESCRIPTION
This related to https://github.com/solarkennedy/puppet-consul/pull/50

I fixed up the tests and added support for providing watches/services/checks via hiera args to the class