### PR TITLE
Enable Hiera Service Definitions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -83,6 +83,44 @@ consul::service { 'redis':
 }
 ```
 
+## Hiera usage example
+
+```
+
+# default agent config ('common.yaml')
+consul::config_dir: '/etc/consul'
+consul::install_method: 'package'
+consul::config_hash:
+  datacenter: 'datacentername'
+  data_dir: '/var/lib/consul'
+  retry_join: 
+    - '10.0.0.1'
+    - '10.0.0.2'
+    - '10.0.0.3'
+
+# master config override ('consul-master.yaml')
+consul::config_hash:
+  log_level: 'INFO'
+  server: true
+  bootstrap_expect: 3
+  ui_dir: '/usr/share/consul/web-ui'
+  client_addr: '0.0.0.0'
+
+# service definitions ('some-service.yaml')
+# Alternative 1
+consul::service:
+  'some-service':
+    tags: [ 'tag-1' , 'tag-a' ]
+    port: 9999
+      
+# Alternative 2
+consul::config_hash:
+  services:
+    'servicename':
+      tags: [ 'some' , 'tags' ]
+      port: 2181
+```
+
 ##Limitations
 
 Depends on the JSON gem, or a modern ruby.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,6 +15,8 @@ class consul::config(
   $purge = true,
 ) {
 
+  include stdlib
+
   if $consul::init_style {
 
     case $consul::init_style {
@@ -95,6 +97,15 @@ class consul::config(
     }
   } else {
     $bootstrap_expect_hash = {}
+  }
+
+  $hash_services = $config_hash['services']
+  $hiera_services = hiera_hash('consul::service')
+
+  $services = merge($hiera_services,$hash_services)
+
+  if $services {
+    create_resources(consul::service,$services)
   }
 
   file { $consul::config_dir:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -115,7 +115,7 @@ class consul::config(
   } ->
   file { 'config.json':
     path    => "${consul::config_dir}/config.json",
-    content => consul_sorted_json(merge($config_hash,$bootstrap_expect_hash,$protocol_hash)),
+    content => consul_sorted_json(merge(delete($config_hash,'services'),$bootstrap_expect_hash,$protocol_hash)),
   }
 
 }


### PR DESCRIPTION
These changes enabled me to add service definitions into Hiera directly, without having to write custom puppet / role based code. Documented in the Readme.