### PR TITLE
Fixes #81 bugfix cycle dependency when specifying a service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,7 +105,5 @@ class consul (
     config_hash => $config_hash_real,
     purge       => $purge_config_dir,
   } ~>
-  class { 'consul::run_service': } ->
-  Class['consul']
-
+  class { 'consul::run_service': }
 }


### PR DESCRIPTION
This seems to fix #81, with no weird side-effects from removing it from the main class.