### PR TITLE
sysv & debian init updates to kill or leave

### DIFF
--- a/templates/consul.debian.erb
+++ b/templates/consul.debian.erb
@@ -17,9 +17,9 @@ PATH=/usr/sbin:/usr/bin:/sbin:/bin:<%= scope.lookupvar('consul::bin_dir') %>
 DESC="Consul service discovery framework"
 NAME=consul
 DAEMON=<%= scope.lookupvar('consul::bin_dir') %>/$NAME
-DAEMON_ARGS="agent -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>"
+PIDFILE=/var/run/$NAME/$NAME.pid
+DAEMON_ARGS="agent -pid-file ${PIDFILE} -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>"
 USER=<%= scope.lookupvar('consul::user') %>
-PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the package is not installed
@@ -36,6 +36,14 @@ SCRIPTNAME=/etc/init.d/$NAME
 . /lib/lsb/init-functions
 
 #
+# Function to create run directory
+#
+mkrundir() {
+        [ ! -d /var/run/consul ] && mkdir -p /var/run/consul
+        chown $USER /var/run/consul
+}
+
+#
 # Function that starts the daemon/service
 #
 do_start()
@@ -45,6 +53,7 @@ do_start()
     #   1 if daemon was already running
     #   2 if daemon could not be started
     echo "Starting consul and backgrounding"
+    mkrundir
     start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid $USER --background --make-pidfile --test > /dev/null \
         || return 1
     start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid $USER --background --make-pidfile -- \
@@ -73,8 +82,10 @@ do_start()
 #
 do_stop()
 {
-    # first try doing this gracefully
-    "$DAEMON" leave
+    # If consul is not acting as a server, exit gracefully
+    if ("${DAEMON}" info 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
+        "$DAEMON" leave
+    fi
     # Return
     #   0 if daemon has been stopped
     #   1 if daemon was already stopped

--- a/templates/consul.sysv.erb
+++ b/templates/consul.sysv.erb
@@ -15,18 +15,45 @@
 
 CONSUL=<%= scope.lookupvar('consul::bin_dir') %>/consul
 CONFIG=<%= scope.lookupvar('consul::config_dir') %>
-PID_FILE=/var/run/consul/pidfile
+PID_FILE=/var/run/consul/consul.pid
 LOG_FILE=/var/log/consul
 
 [ -e /etc/sysconfig/consul ] && . /etc/sysconfig/consul
 
 export GOMAXPROCS=${GOMAXPROCS:-2}
 
+#
+# Create the /var/run/consul directory, which can live on a tmpfs
+# filesystem and be destroyed between reboots.
+#
+mkrundir() {
+        [ ! -d /var/run/consul ] && mkdir -p /var/run/consul
+        chown <%= scope.lookupvar('consul::user') %> /var/run/consul
+}
+
+#
+# Create a PID file if it doesn't already exist, for clean upgrades
+# from previous init-script controlled daemons.
+#
+KILLPROC_OPT="-p ${PID_FILE}"
+mkpidfile() {
+        # Create PID file if it didn't exist
+        mkrundir
+        [ ! -f $PID_FILE ] && pidofproc $CONSUL > $PID_FILE
+        chown <%= scope.lookupvar('consul::user') %> /var/run/consul
+        if [ $? -ne 0 ] ; then
+            rm $PID_FILE
+            KILLPROC_OPT=""
+        fi
+}
+
 start() {
         echo -n "Starting consul: "
+        mkrundir
+        [ -f $PID_FILE ] && rm $PID_FILE
         daemon --user=<%= scope.lookupvar('consul::user') %> \
             --pidfile="$PID_FILE" \
-            "$CONSUL" agent -config-dir "$CONFIG" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE" &
+            "$CONSUL" agent -pid-file "${PID_FILE}" -config-dir "$CONFIG" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE" &
         retcode=$?
         touch /var/lock/subsys/consul
         return $retcode
@@ -34,10 +61,17 @@ start() {
 
 stop() {
         echo -n "Shutting down consul: "
-        "$CONSUL" leave
+        # If consul is not acting as a server, exit gracefully
+        if ("${CONSUL}" info 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
+            "$CONSUL" leave
+        fi
+
+        # If acting as a server, or if leave failed, kill it.
+        mkpidfile
+        killproc $KILLPROC_OPT $CONSUL -9
 
         retcode=$?
-        rm -f /var/lock/subsys/consul
+        rm -f /var/lock/subsys/consul $PID_FILE
         return $retcode
 }
 
@@ -56,7 +90,8 @@ case "$1" in
         start
         ;;
     reload)
-        kill -HUP `cat $PID_FILE`
+        mkpidfile
+        killproc $KILLPROC_OPT $CONSUL -HUP
         ;;
     condrestart)
         [ -f /var/lock/subsys/consul ] && restart || :


### PR DESCRIPTION
This fixes #85. The 'stop' action in init scripts for sysv and Debian
will only 'leave' the cluster if acting as an agent. When running as a
server, as determined by a call to `consul info`, kill the process
instead.

Both updates also enforce the use of a PID file located in a
/var/run/consul directory, writeable by the consul::user configured in
Puppet.