### PR TITLE
Expose id parameter for service definitions

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -26,6 +26,7 @@
 #
 define consul::service(
   $service_name   = $title,
+  $id             = $title,
   $tags           = [],
   $port           = undef,
   $check_ttl      = undef,
@@ -33,7 +34,6 @@ define consul::service(
   $check_interval = undef,
 ) {
   include consul
-  $id = $title
 
   $basic_hash = {
     'id'   => $id,
@@ -69,7 +69,7 @@ define consul::service(
   }
 
   if $port {
-    # implicit conversion from string to int so it won't be quoted in JSON 
+    # implicit conversion from string to int so it won't be quoted in JSON
     $port_hash = {
       port => $port * 1
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,6 +8,9 @@
 # [*service_name*]
 #   Name of the service. Defaults to title.
 #
+# [*id*]
+#   The unique ID of the service on the node. Defaults to title.
+#
 # [*tags*]
 #   Array of strings.
 #


### PR DESCRIPTION
Its useful to be able to override the service ID as these must be unique per node.