### PR TITLE
Consul expects prefix rather than keyprefix in watch config

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,3 +2,4 @@ Kyle Anderson <kyle@xkyle.com>
 Kenny Gatdula <kennygatdula@gmail.com>
 Simon Croome <simon@croome.org>
 Dan Tehranian <tehranian@gmail.com>
+Vik Bhatti <vik@vikbhatti.com>

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -88,7 +88,7 @@ define consul::watch(
         fail('keyprefix is required for watch type of [keyprefix]')
       }
       $type_hash = {
-        keyprefix => $keyprefix,
+        prefix => $keyprefix,
       }
     }
     'service': {

--- a/spec/defines/consul_watch_spec.rb
+++ b/spec/defines/consul_watch_spec.rb
@@ -144,7 +144,7 @@ describe 'consul::watch' do
         it {
           should contain_file('/etc/consul/watch_my_watch.json') \
             .with_content(/"type" *: *"keyprefix"/)
-            .with_content(/"keyprefix" *: *"keyPref"/)
+            .with_content(/"prefix" *: *"keyPref"/)
         }
       end
     end


### PR DESCRIPTION
Consul expects the 'prefix' parameter rather than 'keyprefix' in watch definitions. Test has been updated too.