### PR TITLE
Add consul_acl type and provider

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -119,6 +119,19 @@ See the check.pp docstrings for all available inputs.
 You can also use `consul::checks` which accepts a hash of checks, and makes
 it easy to declare in hiera.
 
+## ACL Definitions
+
+```puppet
+consul_acl { 'ctoken':
+  ensure => 'present',
+  rules  => {'key' => {'test' => {'policy' => 'read'}}},
+  type   => 'client',
+}
+```
+
+Do not use duplicate names, and remember that the ACL ID (a read-only property for this type)
+is used as the token for requests, not the name
+
 ##Limitations
 
 Depends on the JSON gem, or a modern ruby.

--- a/lib/puppet/provider/consul_acl/default.rb
+++ b/lib/puppet/provider/consul_acl/default.rb
@@ -1,0 +1,132 @@
+require 'json'
+require 'net/http'
+require 'uri'
+Puppet::Type.type(:consul_acl).provide(
+  :default
+) do
+  mk_resource_methods
+
+  def self.instances
+    acls = list_resources
+    acls.collect do |acl|
+      new(acl)
+    end
+  end
+
+  def self.list_resources
+    if @acls
+      return @acls
+    end
+
+    # this might be configurable by searching /etc/consul.d
+    # but would break for anyone using nonstandard paths
+    uri = URI('http://localhost:8500/v1/acl')
+    http = Net::HTTP.new(uri.host, uri.port)
+
+    path=uri.request_uri + '/list'
+    req = Net::HTTP::Get.new(path)
+    res = http.request(req)
+
+    if res.code == '200'
+      acls = JSON.parse(res.body)
+    else
+      acls = []
+    end
+
+    nacls = acls.collect do |acl|
+      if !acl['Rules'].empty?
+        { :name   => acl["Name"],
+             :type   => acl["Type"],
+             :rules  => JSON.parse(acl["Rules"]),
+             :id     => acl["ID"],
+             :ensure => :present}
+      else
+        { :name   => acl["Name"],
+             :type   => acl["Type"],
+             :rules  => {},
+             :id     => acl["ID"],
+             :ensure => :present}
+      end
+    end
+
+    @acls = nacls
+    nacls
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def put_acl(method,body)
+    uri = URI('http://localhost:8500/v1/acl')
+    http = Net::HTTP.new(uri.host, uri.port)
+    path = uri.request_uri + "/#{method}"
+    req = Net::HTTP::Put.new(path)
+    if body
+      req.body = body.to_json
+    end
+    res = http.request(req)
+    if res.code != '200'
+      raise(Puppet::Error,"Session #{name} create: invalid return code #{res.code} uri: #{path} body: #{req.body}")
+    end
+  end
+
+  def get_resource_id(name)
+    resources = self.class.list_resources.select do |res|
+      res[:name] == name
+    end
+    # if the user creates multiple with the same name this will do odd things
+    if resources.first
+        return resources.first[:id]
+    else
+        return nil
+    end
+  end
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def flush
+    name = @resource[:name]
+    if @resource[:rules]
+      rules = @resource[:rules].to_json
+    else
+      rules = ""
+    end
+    type = @resource[:type]
+    id = self.get_resource_id(name)
+    if id
+      if @property_flush[:ensure] == :absent
+        put_acl("destroy/#{id}", nil)
+        return
+      end
+      put_acl('update', { "id"    => "#{id}",
+                          "name"  => "#{name}",
+                          "type"  => "#{type}",
+                          "rules" => "#{rules}" })
+
+    else
+      put_acl('create', { "name"  => "#{name}",
+                          "type"  => "#{type}",
+                          "rules" => "#{rules}" })
+    end
+  end
+end

--- a/lib/puppet/type/consul_acl.rb
+++ b/lib/puppet/type/consul_acl.rb
@@ -1,0 +1,39 @@
+Puppet::Type.newtype(:consul_acl) do
+
+  desc <<-'EOD'
+  Manage a consul token and its ACLs.
+  EOD
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc 'Name of the token'
+    validate do |value|
+      raise ArgumentError, "ACL name must be a string" if not value.is_a?(String)
+    end
+  end
+
+  newproperty(:type) do
+    desc 'Type of token'
+    newvalues('client', 'management')
+    defaultto 'client'
+  end
+
+  newproperty(:rules) do
+    desc 'hash of ACL rules for this token'
+    defaultto {}
+    validate do |value|
+      raise ArgumentError, "ACL rules must be provided as a hash" if not value.is_a?(Hash)
+    end
+  end
+
+  newproperty(:id) do
+    desc 'ID of token'
+    validate do |v|
+      raise(Puppet::Error, 'This is a read only property')
+    end
+  end
+
+  autorequire(:service) do
+    ['consul']
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,7 @@ class consul (
   $services          = {},
   $watches           = {},
   $checks            = {},
+  $acls              = {},
 ) inherits consul::params {
 
   validate_bool($purge_config_dir)
@@ -72,6 +73,7 @@ class consul (
   validate_hash($services)
   validate_hash($watches)
   validate_hash($checks)
+  validate_hash($acls)
 
   $config_hash_real = merge($config_defaults, $config_hash)
   validate_hash($config_hash_real)
@@ -98,6 +100,10 @@ class consul (
 
   if $checks {
     create_resources(consul::check, $checks)
+  }
+
+  if $acls {
+    create_resources(consul_acl, $acls)
   }
 
   class { 'consul::install': } ->

--- a/spec/unit/puppet/type/consul_acl_spec.rb
+++ b/spec/unit/puppet/type/consul_acl_spec.rb
@@ -1,0 +1,46 @@
+describe Puppet::Type.type(:consul_acl) do
+
+  samplerules = {
+    'key' => {
+      'test' => {
+        'policy' => 'read'
+      }
+    }
+  }
+
+  it 'should fail if type is not client or management' do
+    expect do
+      Puppet::Type.type(:consul_acl).new(:name => 'foo', :type => 'blah')
+    end.to raise_error(Puppet::Error, /Invalid value/)
+  end
+
+  it 'should fail if rules is not a hash' do
+    expect do
+      Puppet::Type.type(:consul_acl).new(:name => 'foo', :rules => 'blah')
+    end.to raise_error(Puppet::Error, /ACL rules must be provided as a hash/)
+  end
+
+  it 'should fail if no name is provided' do
+    expect do
+      Puppet::Type.type(:consul_acl).new(:type => 'client')
+    end.to raise_error(Puppet::Error, /Title or name must be provided/)
+  end
+
+  context 'with type and rules provided' do
+    before :each do
+      @acl = Puppet::Type.type(:consul_acl).new(
+        :name => 'testing',
+        :type => 'management',
+        :rules => samplerules
+      )
+    end
+
+    it 'should accept a type' do
+      expect(@acl[:type]).to eq(:management)
+    end
+
+    it 'should accept a hash of rules' do
+      expect(@acl[:rules]).to eq(samplerules)
+    end
+  end
+end


### PR DESCRIPTION
This patch adds support for managing consul ACLs.
Rules can be specified in a ruby hash, while type
must be either 'client' or 'management'.

Example:
consul_acl { 'ctoken':
  ensure => 'present',
  rules  => {'key' => {'test' => {'policy' => 'read'}}},
  type   => 'client',
}

While consul does not enforce unique names, the provider will
not behave consistently if the user manually creates ACLs with the
same name and subsequently attempts to manage them with puppet.