### PR TITLE
Use fixed titles for packages so that dependencies are easier

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -51,13 +51,15 @@ class consul::install {
 
   } elsif $consul::install_method == 'package' {
 
-    package { $consul::package_name:
+    package { 'consul':
       ensure => $consul::package_ensure,
+      name   => $consul::package_name,
     }
 
     if $consul::ui_dir {
-      package { $consul::ui_package_name:
+      package { 'consul_ui':
         ensure => $consul::ui_package_ensure,
+        name   => $consul::ui_package_name,
       }
     }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -68,7 +68,10 @@ describe 'consul' do
       :package_ensure => 'specific_release',
       :package_name   => 'custom_consul_package'
     }}
-    it { should contain_package('custom_consul_package').with(:ensure => 'specific_release') }
+    it { should contain_package('consul').with({
+      :name   => 'custom_consul_package',
+      :ensure => 'specific_release',
+    })}
   end
 
   context "When installing via URL by default" do
@@ -107,7 +110,10 @@ describe 'consul' do
         'ui_dir'   => '/dir1/dir2',
       },
     }}
-    it { should contain_package('custom_consul_ui_package').with(:ensure => 'specific_ui_release') }
+    it { should contain_package('consul_ui').with({
+      :name  => 'custom_consul_ui_package',
+      :ensure => 'specific_ui_release'
+    })}
   end
 
   context "When installing UI via URL by default" do


### PR DESCRIPTION
I'm submitting this patch on behalf of @sorenh, b/c we are carrying it downstream at the moment. Having static titles makes it possible for us to set up dependencies on resources inside of the classes without having to know the values of variables. I think it's a good practice in general to only let namevars be dynamic and always make title's static.
