### PR TITLE
Notify consul service

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -71,5 +71,5 @@ define consul::check(
   File[$consul::config_dir] ->
   file { "${consul::config_dir}/check_${id}.json":
     content => template('consul/check.json.erb'),
-  } ~> Class['consul::run_service']
+  } ~> Service['consul']
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -87,5 +87,5 @@ define consul::service(
   File[$consul::config_dir] ->
   file { "${consul::config_dir}/service_${id}.json":
     content => consul_sorted_json($service_hash),
-  } ~> Class['consul::run_service']
+  } ~> Service['consul']
 }


### PR DESCRIPTION
This PR changes the notification dependency to notify the Consul Service instead of the Run Service Class.

In my tests this did result in correctly restarted consul instances after configuration changes. Without this patch consul was lacking necessary restarts/reloads.