### PR TITLE
Allow multiple versions to be installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,6 +90,10 @@ class consul (
     warning('data_dir must be set to install consul web ui')
   }
 
+  if $config_hash_real['download_dir'] {
+    $download_dir = $config_hash_real['download_dir']
+  }
+
   if $services {
     create_resources(consul::service, $services)
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,20 +15,36 @@ class consul::install {
 
   if $consul::install_method == 'url' {
 
+    $base_dir = $consul::download_dir ? {
+      undef   => $consul::bin_dir,
+      default => $consul::download_dir
+    }
+    $download_dir = "${base_dir}/consul_${consul::version}_${consul::os}_${consul::arch}"
+
     if $::operatingsystem != 'darwin' {
       ensure_packages(['unzip'])
     }
+    file { $download_dir:
+      ensure => 'directory',
+      owner  => $consul::user,
+      group  => $consul::group,
+      mode   => '0755',
+    } ->
     staging::file { 'consul.zip':
       source => $consul::download_url
     } ->
     staging::extract { 'consul.zip':
-      target  => $consul::bin_dir,
-      creates => "${consul::bin_dir}/consul",
+      target  => $download_dir,
+      creates => "${download_dir}/consul",
     } ->
-    file { "${consul::bin_dir}/consul":
+    file { "${download_dir}/consul":
       owner => 'root',
       group => 0, # 0 instead of root because OS X uses "wheel".
       mode  => '0555',
+    } ->
+    file { "${consul::bin_dir}/consul":
+      ensure => 'symlink',
+      target => "${download_dir}/consul",
     }
 
     if ($consul::ui_dir and $consul::data_dir) {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -73,6 +73,9 @@ describe 'consul' do
 
   context "When installing via URL by default" do
     it { should contain_staging__file('consul.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.4.1_linux_amd64.zip') }
+    it { should contain_file('/usr/local/bin/consul_0.4.1_linux_amd64').with(:ensure => :directory) }
+    it { should contain_file('/usr/local/bin/consul_0.4.1_linux_amd64/consul').with(:mode => '0555') }
+    it { should contain_file('/usr/local/bin/consul').with(:target => '/usr/local/bin/consul_0.4.1_linux_amd64/consul') }
   end
 
   context "When installing via URL by with a special version" do
@@ -80,6 +83,9 @@ describe 'consul' do
       :version   => '42',
     }}
     it { should contain_staging__file('consul.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/42_linux_amd64.zip') }
+    it { should contain_file('/usr/local/bin/consul_42_linux_amd64').with(:ensure => :directory) }
+    it { should contain_file('/usr/local/bin/consul_42_linux_amd64/consul').with(:mode => '0555') }
+    it { should contain_file('/usr/local/bin/consul').with(:target => '/usr/local/bin/consul_42_linux_amd64/consul') }
   end
 
   context "When installing via URL by with a custom url" do
@@ -87,8 +93,43 @@ describe 'consul' do
       :download_url   => 'http://myurl',
     }}
     it { should contain_staging__file('consul.zip').with(:source => 'http://myurl') }
+    it { should contain_file('/usr/local/bin/consul_0.4.1_linux_amd64').with(:ensure => :directory) }
+    it { should contain_file('/usr/local/bin/consul_0.4.1_linux_amd64/consul').with(:mode => '0555') }
+    it { should contain_file('/usr/local/bin/consul').with(:target => '/usr/local/bin/consul_0.4.1_linux_amd64/consul') }
   end
 
+  context "When installing via URL with a custom download directory" do
+    let(:params) {{
+      :config_hash => {
+        'download_dir' => '/opt'
+      }
+    }}
+    it { should contain_staging__file('consul.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.4.1_linux_amd64.zip') }
+    it { should contain_file('/opt/consul_0.4.1_linux_amd64').with(:ensure => :directory) }
+    it { should contain_file('/opt/consul_0.4.1_linux_amd64/consul').with(:mode => '0555') }
+    it { should contain_file('/usr/local/bin/consul').with(:target => '/opt/consul_0.4.1_linux_amd64/consul') }
+  end
+
+  context 'When installed via URL on a different arch' do
+    let(:facts) {{ :architecture => 'i386' }}
+    it { should contain_staging__file('consul.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.4.1_linux_386.zip') }
+    it { should contain_file('/usr/local/bin/consul_0.4.1_linux_386').with(:ensure => :directory) }
+    it { should contain_file('/usr/local/bin/consul_0.4.1_linux_386/consul').with(:mode => '0555') }
+    it { should contain_file('/usr/local/bin/consul').with(:target => '/usr/local/bin/consul_0.4.1_linux_386/consul') }
+  end
+
+  context 'When installed via URL on a different arch with a custom download directory' do
+    let(:facts) {{ :architecture => 'i386' }}
+    let(:params) {{
+      :config_hash => {
+        'download_dir' => '/opt'
+      }
+    }}
+    it { should contain_staging__file('consul.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.4.1_linux_386.zip') }
+    it { should contain_file('/opt/consul_0.4.1_linux_386').with(:ensure => :directory) }
+    it { should contain_file('/opt/consul_0.4.1_linux_386/consul').with(:mode => '0555') }
+    it { should contain_file('/usr/local/bin/consul').with(:target => '/opt/consul_0.4.1_linux_386/consul') }
+  end
 
   context 'When requesting to install via a package with defaults' do
     let(:params) {{


### PR DESCRIPTION
Using this patch downstream to make upgrading a little easier.

* Added ability to specify download directory
  * Defaults to current location of `/usr/local/bin`
* Downloads into versioned directory
* Creates symlink to versioned binary