### PR TITLE
Anchor the consul install/config/run_service classes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,10 +106,14 @@ class consul (
     create_resources(consul_acl, $acls)
   }
 
+  anchor {'consul_first': }
+  ->
   class { 'consul::install': } ->
   class { 'consul::config':
     config_hash => $config_hash_real,
     purge       => $purge_config_dir,
   } ~>
   class { 'consul::run_service': }
+  ->
+  anchor {'consul_last': }
 }


### PR DESCRIPTION
This fixes dependency issues on underlying packages and services.

For me this helped to solve a dependency issue between a yum repo and the consul package. I had to add another anchor around the calling consul class:

```` 
yum::repo { 'my-repo': }
 
anchor {'my_consul_first': }
->
class { '::consul':
    install_method => 'package',
    package_ensure => '0.5.0-2.el6',
    require        => Yum::Repo['my-repo'],
}
->
anchor {'my_consul_last': }
````