### PR TITLE
Allow setting of the umask for the consul daemon.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,7 @@ class consul (
   $watches           = {},
   $checks            = {},
   $acls              = {},
+  $umask             = '0022',
 ) inherits consul::params {
 
   validate_bool($purge_config_dir)

--- a/templates/consul.debian.erb
+++ b/templates/consul.debian.erb
@@ -56,7 +56,7 @@ do_start()
     mkrundir
     start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid $USER --background --make-pidfile --test > /dev/null \
         || return 1
-    start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid $USER --background --make-pidfile -- \
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid $USER --background --make-pidfile <%= scope.lookupvar('consul::umask') %> -- \
         $DAEMON_ARGS \
         || return 2
 

--- a/templates/consul.launchd.erb
+++ b/templates/consul.launchd.erb
@@ -5,6 +5,7 @@
     <key>Label</key>             <string>io.consul.daemon</string>
     <key>UserName</key>          <string><%= scope.lookupvar('consul::user') %></string>
     <key>GroupName</key>         <string><%= scope.lookupvar('consul::group') %></string>
+    <key>Umask</key>             <string><%= scope.lookupvar('consul::umask') %></string>
 <% if scope.lookupvar('consul::service_enable') %>
     <key>Disabled</key>          <false/>
 <% else %>

--- a/templates/consul.sles.erb
+++ b/templates/consul.sles.erb
@@ -36,6 +36,7 @@ case "$1" in
         echo -n "Starting consul "
         ## Start daemon with startproc(8). If this fails
         ## the return value is set appropriately by startproc.
+        umask <%= scope.lookupvar('consul::umask') %>
         startproc $CONSUL_BIN agent -config-dir "$CONFIG_DIR" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE"
 
         # Remember status and be verbose

--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -6,6 +6,7 @@ After=basic.target network.target
 [Service]
 User=<%= scope.lookupvar('consul::user') %>
 Group=<%= scope.lookupvar('consul::group') %>
+Umask=<%= scope.lookupvar('consul::umask') %>
 ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent \
   -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID

--- a/templates/consul.sysv.erb
+++ b/templates/consul.sysv.erb
@@ -52,7 +52,7 @@ start() {
         mkrundir
         [ -f $PID_FILE ] && rm $PID_FILE
         daemon --user=<%= scope.lookupvar('consul::user') %> \
-            --pidfile="$PID_FILE" \
+            --pidfile="$PID_FILE" --umask=<%= scope.lookupvar('consul::umask') %> \
             "$CONSUL" agent -pid-file "${PID_FILE}" -config-dir "$CONFIG" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE" &
         retcode=$?
         touch /var/lock/subsys/consul

--- a/templates/consul.upstart.erb
+++ b/templates/consul.upstart.erb
@@ -6,6 +6,7 @@ stop on runlevel [06]
 env CONSUL=<%= scope.lookupvar('consul::bin_dir') %>/consul
 env CONFIG=<%= scope.lookupvar('consul::config_dir') %>
 
+umask <%= scope.lookupvar('consul::umask') %>
 
 script
     # read settings like GOMAXPROCS from "/etc/default/consul", if available.


### PR DESCRIPTION
This allows setting of the umask before spawning the consul daemon. I'd like to be able to store secrets in Consul, but by default Consul creates files as 0644 and directories as 0755, which leaves these secrets readable to anyone on the system.

Consul does respect umask, however, so by setting it before launching, we can avoid creating these files as world-readable.

Currently this defaults to 0022, (not writeable by world or group), but in a secure environment it's probably good to set to 0027 or 0077. I could be convinced to change the default to one of those.