### PR TITLE
Update puppetlabs-stdlib dependency to 4.2.0 for the delete_undef_values function

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/solarkennedy/puppet-consul/issues",
   "description": "Configures Consul by Hashicorp",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 0.1.6 <5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0 <5.0.0"},
     {"name":"nanliu/staging","version_requirement":">=0.4.0 <2.0.0"}
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
I also perused through the rest of the manifests looking for other functions that might be in a version later than 4.2 and didn't see anything else.
Closes #109