### PR TITLE
Ensure package unzip is not defined

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,7 +15,7 @@ class consul::install {
 
   if $consul::install_method == 'url' {
 
-    if $::operatingsystem != 'darwin' {
+    if ($::operatingsystem != 'darwin' and ! defined(Package['unzip'])) {
       ensure_packages(['unzip'])
     }
     staging::file { 'consul.zip':


### PR DESCRIPTION
Hi,

We need to ensure that unzip package is not defined elsewhere in the catalog. Otherwise we have a compilation failure:

`Error 400 on SERVER: Duplicate declaration: Package[unzip] is already declared in file ...`

This pull request check that.