### PR TITLE
Set provider on consul service

### DIFF
--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -12,9 +12,10 @@ class consul::run_service {
 
   if $consul::manage_service == true {
     service { 'consul':
-      ensure => $consul::service_ensure,
-      name   => $init_selector,
-      enable => $consul::service_enable,
+      ensure   => $consul::service_ensure,
+      name     => $init_selector,
+      enable   => $consul::service_enable,
+      provider => $consul::init_style,
     }
   }
 


### PR DESCRIPTION
Hi,

If provider is not set, service management does not work on Debian 8, we have an error:

`Error: /Stage[main]/Consul::Run_service/Service[consul]: Could not evaluate: Could not find init script for 'consul' `

This PR set provider defined in `consul::params`
