### PR TITLE
Supply optional token for ACL changes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -152,6 +152,11 @@ consul_acl { 'ctoken':
 Do not use duplicate names, and remember that the ACL ID (a read-only property for this type)
 is used as the token for requests, not the name
 
+Optionally, you may supply an `acl_api_token`.  This will allow you to create
+ACLs if the anonymous token doesn't permit ACL changes (which is likely).
+The api token may be the master token, another management token, or any
+client token with sufficient privileges.
+
 ##Limitations
 
 Depends on the JSON gem, or a modern ruby.

--- a/lib/puppet/type/consul_acl.rb
+++ b/lib/puppet/type/consul_acl.rb
@@ -18,6 +18,14 @@ Puppet::Type.newtype(:consul_acl) do
     defaultto 'client'
   end
 
+  newproperty(:acl_api_token) do
+    desc 'Token for accessing the ACL API'
+    validate do |value|
+      raise ArgumentError, "ACL API token must be a string" if not value.is_a?(String)
+    end
+    defaultto ''
+  end
+
   newproperty(:rules) do
     desc 'hash of ACL rules for this token'
     defaultto {}


### PR DESCRIPTION
It seems likely that the Consul cluster will not allow the anonymous token to make ACL changes, so it would be nice if you could supply a token with the right privileges.  I tried setting that up in this PR.  I had to delete the prefetch methods, since they wouldn't have access to the token.  However maybe there is a better way to handle it.