### PR TITLE
Switch to using start-stop-daemon for consul upstart init script

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -241,7 +241,8 @@ describe 'consul' do
     }}
     it { should contain_user('custom_consul_user').with(:ensure => :present) }
     it { should contain_group('custom_consul_group').with(:ensure => :present) }
-    it { should contain_file('/etc/init/consul.conf').with_content(/sudo -u custom_consul_user -g custom_consul_group/) }
+    it { should contain_file('/etc/init/consul.conf').with_content(/env USER=custom_consul_user/) }
+    it { should contain_file('/etc/init/consul.conf').with_content(/env GROUP=custom_consul_group/) }
   end
 
   context "When the user provides a hash of services" do
@@ -389,7 +390,7 @@ describe 'consul' do
     let(:params) {{
       :extra_options => '-some-extra-argument'
     }}
-    it { should contain_file('/etc/init/consul.conf').with_content(/\$CONSUL agent .*-some-extra-argument$/) }
+    it { should contain_file('/etc/init/consul.conf').with_content(/\$CONSUL -S -- agent .*-some-extra-argument$/) }
   end
   # Service Stuff
 

--- a/templates/consul.upstart.erb
+++ b/templates/consul.upstart.erb
@@ -5,14 +5,26 @@ stop on runlevel [06]
 
 env CONSUL=<%= scope.lookupvar('consul::bin_dir') %>/consul
 env CONFIG=<%= scope.lookupvar('consul::config_dir') %>
+env USER=<%= scope.lookupvar('consul::user') %>
+env GROUP=<%= scope.lookupvar('consul::group') %>
+env DEFAULTS=/etc/default/consul
+env RUNDIR=/var/run/consul
+env PID_FILE=/var/run/consul/consul.pid
 
+pre-start script
+  [ -e $DEFAULTS ] && . $DEFAULTS
+
+  mkdir -p $RUNDIR           || true
+  chmod 0750 $RUNDIR         || true
+  chown $USER:$GROUP $RUNDIR || true
+end script
 
 script
     # read settings like GOMAXPROCS from "/etc/default/consul", if available.
-    [ -e /etc/default/consul ] && . /etc/default/consul
+    [ -e $DEFAULTS ] && . $DEFAULTS
 
     export GOMAXPROCS=${GOMAXPROCS:-2}
-    exec sudo -u <%= scope.lookupvar('consul::user') %> -g <%= scope.lookupvar('consul::group') %> $CONSUL agent -config-dir $CONFIG <%= scope.lookupvar('consul::extra_options') %>
+    exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $CONSUL -S -- agent -config-dir $CONFIG -pid-file $PID_FILE <%= scope.lookupvar('consul::extra_options') %>
 end script
 
 respawn


### PR DESCRIPTION
This avoids the use of sudo and permits passing the GOMAXPROCS setting
via the environment. In addition this change exposes the pid file again so
that other users can signal the agent.
Fixes #126