### PR TITLE
Change name of File['config.json'] to File['consul config.json']

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -102,7 +102,7 @@ class consul::config(
     purge   => $purge,
     recurse => $purge,
   } ->
-  file { 'config.json':
+  file { 'consul config.json':
     path    => "${consul::config_dir}/config.json",
     content => consul_sorted_json(merge($config_hash,$bootstrap_expect_hash,$protocol_hash)),
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -185,8 +185,8 @@ describe 'consul' do
       :config_hash =>
         { 'bootstrap_expect' => '5' }
     }}
-    it { should contain_file('config.json').with_content(/"bootstrap_expect":5/) }
-    it { should_not contain_file('config.json').with_content(/"bootstrap_expect":"5"/) }
+    it { should contain_file('consul config.json').with_content(/"bootstrap_expect":5/) }
+    it { should_not contain_file('consul config.json').with_content(/"bootstrap_expect":"5"/) }
   end
 
   context 'Config_defaults is used to provide additional config' do
@@ -198,8 +198,8 @@ describe 'consul' do
           'bootstrap_expect' => '5',
       }
     }}
-    it { should contain_file('config.json').with_content(/"bootstrap_expect":5/) }
-    it { should contain_file('config.json').with_content(/"data_dir":"\/dir1"/) }
+    it { should contain_file('consul config.json').with_content(/"bootstrap_expect":5/) }
+    it { should contain_file('consul config.json').with_content(/"data_dir":"\/dir1"/) }
   end
 
   context 'Config_defaults is used to provide additional config and is overridden' do
@@ -213,9 +213,9 @@ describe 'consul' do
           'server' => true,
       }
     }}
-    it { should contain_file('config.json').with_content(/"bootstrap_expect":5/) }
-    it { should contain_file('config.json').with_content(/"data_dir":"\/dir1"/) }
-    it { should contain_file('config.json').with_content(/"server":true/) }
+    it { should contain_file('consul config.json').with_content(/"bootstrap_expect":5/) }
+    it { should contain_file('consul config.json').with_content(/"data_dir":"\/dir1"/) }
+    it { should contain_file('consul config.json').with_content(/"server":true/) }
   end
 
   context "When asked not to manage the user" do


### PR DESCRIPTION
I wrote another module that also happens to create a File['config.json'] resource, and ran into a conflict with this one.

I've already fixed the other module, so this is not an issue for me, but it seems good to namespace things if possible.