### PR TITLE
Escape the ID & make fixtures useable more widely

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     staging: "https://github.com/nanliu/puppet-staging.git"
   symlinks:
     consul: "#{source_dir}"

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -61,8 +61,9 @@ define consul::check(
 
   consul_validate_checks($check_hash[check])
 
+  $escaped_id = regsubst($id,'\/','_')
   File[$consul::config_dir] ->
-  file { "${consul::config_dir}/check_${id}.json":
+  file { "${consul::config_dir}/check_${escaped_id}.json":
     content => template('consul/check.json.erb'),
   } ~> Class['consul::run_service']
 }

--- a/spec/defines/consul_check_spec.rb
+++ b/spec/defines/consul_check_spec.rb
@@ -160,4 +160,14 @@ describe 'consul::check' do
       should raise_error(Puppet::Error)
     }
   end
+  describe 'with a / in the id' do
+    let(:params) {{
+      'ttl' => '30s',
+      'service_id' => 'my_service',
+      'id' => 'aa/bb',
+    }}
+    it { should contain_file("/etc/consul/check_aa_bb.json") \
+        .with_content(/"id" *: *"aa\/bb"/)
+    }
+  end
 end


### PR DESCRIPTION
* change fixture source to https to make it work behind corporate firewalls & proxies
* make it possible to use / within an id