### PR TITLE
Add an exec to daemon-reload systemctl when the unit-file changes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -109,9 +109,10 @@ class consul::config(
 
 
   exec { 'systemctl daemon-reload':
-    path      => ['/bin','/usr/bin','/sbin','/usr/sbin'],
-    command   => "systemctl daemon-reload",
-    subscribe => File['/lib/systemd/system/consul.service'],
+    path        => ['/bin','/usr/bin','/sbin','/usr/sbin'],
+    command     => "systemctl daemon-reload",
+    subscribe   => File['/lib/systemd/system/consul.service'],
+    refreshonly => true,
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -110,7 +110,7 @@ class consul::config(
 
   exec { 'systemctl daemon-reload':
     path        => ['/bin','/usr/bin','/sbin','/usr/sbin'],
-    command     => "systemctl daemon-reload",
+    command     => 'systemctl daemon-reload',
     subscribe   => File['/lib/systemd/system/consul.service'],
     refreshonly => true,
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -107,4 +107,11 @@ class consul::config(
     content => consul_sorted_json(merge($config_hash,$bootstrap_expect_hash,$protocol_hash)),
   }
 
+
+  exec { 'systemctl daemon-reload':
+    path      => ['/bin','/usr/bin','sbin','/usr/sbin'],
+    command   => "systemctl daemon-reload",
+    subscribe => File['/lib/systemd/system/consul.service'],
+  }
+
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,11 +39,9 @@ class consul::config(
           owner   => 'root',
           group   => 'root',
           content => template('consul/consul.systemd.erb'),
-        }
-        exec { 'systemctl daemon-reload':
-          path        => ['/bin','/usr/bin','/sbin','/usr/sbin'],
-          command     => 'systemctl daemon-reload',
-          subscribe   => File['/lib/systemd/system/consul.service'],
+        }~>
+        exec { 'consul-systemd-reload':
+          command     => '/usr/bin/systemctl daemon-reload',
           refreshonly => true,
         }
       }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -109,7 +109,7 @@ class consul::config(
 
 
   exec { 'systemctl daemon-reload':
-    path      => ['/bin','/usr/bin','sbin','/usr/sbin'],
+    path      => ['/bin','/usr/bin','/sbin','/usr/sbin'],
     command   => "systemctl daemon-reload",
     subscribe => File['/lib/systemd/system/consul.service'],
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,6 +40,12 @@ class consul::config(
           group   => 'root',
           content => template('consul/consul.systemd.erb'),
         }
+        exec { 'systemctl daemon-reload':
+          path        => ['/bin','/usr/bin','/sbin','/usr/sbin'],
+          command     => 'systemctl daemon-reload',
+          subscribe   => File['/lib/systemd/system/consul.service'],
+          refreshonly => true,
+        }
       }
       'sysv' : {
         file { '/etc/init.d/consul':
@@ -105,14 +111,6 @@ class consul::config(
   file { 'consul config.json':
     path    => "${consul::config_dir}/config.json",
     content => consul_sorted_json(merge($config_hash,$bootstrap_expect_hash,$protocol_hash)),
-  }
-
-
-  exec { 'systemctl daemon-reload':
-    path        => ['/bin','/usr/bin','/sbin','/usr/sbin'],
-    command     => 'systemctl daemon-reload',
-    subscribe   => File['/lib/systemd/system/consul.service'],
-    refreshonly => true,
   }
 
 }


### PR DESCRIPTION
When the unit-file changes we need to issue a 'systemctl daemon-reload'.   I've had to change the bin_dir parameter, which changes the unit-file, but currently doesn't notify systemd of this.