### PR TITLE
Make consul::install optional

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,21 @@ class { '::consul':
     'log_level'  => 'INFO',
     'node_name'  => 'agent',
     'retry_join' => ['172.16.0.1'],
+  }ii
+}
+```
+Disable install and service components:
+```puppet
+class { '::consul':
+  install_method => 'none',
+  init_style     => false,
+  manage_service => false,
+  config_hash => {
+    'data_dir'   => '/opt/consul',
+    'datacenter' => 'east-aws',
+    'log_level'  => 'INFO',
+    'node_name'  => 'agent',
+    'retry_join' => ['172.16.0.1'],
   }
 }
 ```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,9 @@
 #   Use this to populate the JSON config file for consul.
 #
 # [*install_method*]
-#   Defaults to `url` but can be `package` if you want to install via a system package.
+#   Valid strings: `package` - install via system package
+#                  `url`     - download and extract from a url. Defaults to `url`.
+#                  `none`    - disable install.
 #
 # [*package_name*]
 #   Only valid when the install_method == package. Defaults to `consul`.

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -110,6 +110,16 @@ describe 'consul' do
     it { should contain_package('custom_consul_ui_package').with(:ensure => 'specific_ui_release') }
   end
 
+  context 'When requesting to not to install' do
+    let(:params) {{
+      :install_method => 'none'
+    }}
+    it { should_not contain_package('consul') }
+    it { should_not contain_package('consul_ui') }
+    it { should_not contain_staging__file('consul.zip') }
+    it { should_not contain_staging__file('consul_web_ui.zip') }
+  end
+
   context "When installing UI via URL by default" do
     let(:params) {{
       :config_hash => {


### PR DESCRIPTION
Added a check against $install_method for the string 'none'. If found, nothing is downloaded or installed.