### PR TITLE
reorder resources for install_method => package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,12 +4,14 @@
 #
 class consul::install {
 
-  if $consul::data_dir {
-    file { $consul::data_dir:
-      ensure => 'directory',
-      owner  => $consul::user,
-      group  => $consul::group,
-      mode   => '0755',
+  if $consul::manage_user {
+    user { $consul::user:
+      ensure => 'present',
+    }
+  }
+  if $consul::manage_group {
+    group { $consul::group:
+      ensure => 'present',
     }
   }
 
@@ -66,14 +68,13 @@ class consul::install {
     }
   }
 
-  if $consul::manage_user {
-    user { $consul::user:
-      ensure => 'present',
+  if $consul::data_dir {
+    file { $consul::data_dir:
+      ensure => 'directory',
+      owner  => $consul::user,
+      group  => $consul::group,
+      mode   => '0755',
     }
   }
-  if $consul::manage_group {
-    group { $consul::group:
-      ensure => 'present',
-    }
-  }
+
 }


### PR DESCRIPTION
This PR is in response to this problem:

Create consul package with fpm, set user/group to consul
Set data_dir to /var/consul/data

Problem:
Package cannot install because consul u:g are not created yet (can't be done with FPM packages ATM)
Puppet error creating /var/consul/data (parent dir doesn't exist)

Solution:
This really is only a partial solution, but I'm not sure how to make a better solution without some deep nasty conditionals with the different install methods.  This solution will work with the default "manifest" ordering (processing is top down), but will break if ordering is set to random.  