### PR TITLE
create user/group as system accounts

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -69,11 +69,13 @@ class consul::install {
   if $consul::manage_user {
     user { $consul::user:
       ensure => 'present',
+      system => true,
     }
   }
   if $consul::manage_group {
     group { $consul::group:
       ensure => 'present',
+      system => true,
     }
   }
 }


### PR DESCRIPTION
Service user/groups should be created as system accounts (IMO).  Not creating them as system accounts causes issues when using a directory service.