### PR TITLE
upstart: Agents should gracefully leave cluster on stop

### DIFF
--- a/templates/consul.upstart.erb
+++ b/templates/consul.upstart.erb
@@ -29,8 +29,8 @@ end script
 
 pre-stop script
     # Only leave the cluster if running as an agent
-    if (sudo -u $USER -g $GROUP $CONSUL info 2>/dev/null | grep -q 'server = false' 2>/dev/null); then
-        exec sudo -u $USER -g $GROUP $CONSUL leave
+    if ($CONSUL info 2>/dev/null | grep -q 'server = false' 2>/dev/null); then
+        exec $CONSUL leave
     fi
 end script
 

--- a/templates/consul.upstart.erb
+++ b/templates/consul.upstart.erb
@@ -27,6 +27,13 @@ script
     exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $CONSUL -S -- agent -config-dir $CONFIG -pid-file $PID_FILE <%= scope.lookupvar('consul::extra_options') %>
 end script
 
+pre-stop script
+    # Only leave the cluster if running as an agent
+    if (sudo -u $USER -g $GROUP $CONSUL info 2>/dev/null | grep -q 'server = false' 2>/dev/null); then
+        exec sudo -u $USER -g $GROUP $CONSUL leave
+    fi
+end script
+
 respawn
 respawn limit 10 10
 kill timeout 10


### PR DESCRIPTION
Similar to PR #87  but for upstart.

Tested with Ubuntu 14.04:

```
Jun 30 12:30:49 ip-10-0-3-159 puppet-user[19088]: (Class[Consul::Run_service]) Scheduling refresh of Service[consul]
Jun 30 12:30:49 ip-10-0-3-159 consul[18056]: agent.rpc: Accepted client: 127.0.0.1:32928
Jun 30 12:30:49 ip-10-0-3-159 consul[18056]: agent.rpc: Accepted client: 127.0.0.1:32929
Jun 30 12:30:49 ip-10-0-3-159 consul[18056]: agent.rpc: Graceful leave triggered
Jun 30 12:30:49 ip-10-0-3-159 consul[18056]: consul: client starting leave
Jun 30 12:30:49 ip-10-0-3-159 consul[18056]: serf: EventMemberLeave: ip-10-0-3-159 10.0.3.159
Jun 30 12:30:49 ip-10-0-3-159 consul[18056]: agent: requesting shutdown
Jun 30 12:30:49 ip-10-0-3-159 consul[18056]: consul: shutting down client
Jun 30 12:30:49 ip-10-0-3-159 consul[18056]: agent: shutdown complete
Jun 30 12:30:49 ip-10-0-3-159 puppet-user[19088]: (/Stage[main]/Consul::Run_service/Service[consul]) Triggered 'refresh' from 1 events
Jun 30 12:30:49 ip-10-0-3-159 consul[19801]: serf: EventMemberJoin: ip-10-0-3-159 10.0.3.159
Jun 30 12:30:49 ip-10-0-3-159 consul[19801]: agent: failed to sync remote state: No known Consul servers
Jun 30 12:30:49 ip-10-0-3-159 consul[19801]: agent: Joining cluster...
Jun 30 12:30:49 ip-10-0-3-159 consul[19801]: agent: (LAN) joining: [consul.staging.local]
```