### PR TITLE
Adding groups parameter to user definition

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@ class consul (
   $manage_user           = true,
   $user                  = 'consul',
   $manage_group          = true,
+  $extra_groups          = [],
   $purge_config_dir      = true,
   $group                 = 'consul',
   $join_wan              = false,
@@ -76,6 +77,7 @@ class consul (
 
   validate_bool($purge_config_dir)
   validate_bool($manage_user)
+  validate_array($extra_groups)
   validate_bool($manage_service)
   validate_hash($config_hash)
   validate_hash($config_defaults)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -79,6 +79,7 @@ class consul::install {
     user { $consul::user:
       ensure => 'present',
       system => true,
+      groups => $consul::extra_groups,
     }
 
     if $consul::manage_group {


### PR DESCRIPTION
Allows you to add the consul user to an array of groups, so the agent can for example execute watch handlers as consul but access/manage items on the filesystem that aren't owned by the consul user.