### PR TITLE
Modify consul_validate_checks to work with ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,18 @@ source "http://rubygems.org"
 group :test do
   gem "rake"
   gem 'beaker', '~> 1.11.0'
-  gem "puppet-blacksmith"
+  gem "retriable", '~> 1.4.1'
+  gem "rest-client", '<= 1.7.0'
+  gem "puppet-blacksmith", '~> 2.3.1'
   gem "puppet", '~> 3.7.0'
   gem "puppet-lint"
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "rspec", '~> 3.1.0'
+  gem "rspec-core", '~> 3.1.7'
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"
   gem "hiera-puppet-helper"
+  gem "nokogiri", '~> 1.5.10'
 end
 
 group :development do

--- a/lib/puppet/parser/functions/consul_validate_checks.rb
+++ b/lib/puppet/parser/functions/consul_validate_checks.rb
@@ -6,26 +6,26 @@ def validate_checks(obj)
       end
     when Hash
         if (obj.key?("http") && obj.key?("script"))
-          raise Puppet::ParseError('script and http must not be defined together')
+          raise Puppet::ParseError.new('script and http must not be defined together')
         end
 
         if obj.key?("ttl")
           if (obj.key?("http") || obj.key?("script") || obj.key?("interval"))
-            raise Puppet::ParseError('script or http must not be defined for ttl checks')
+            raise Puppet::ParseError.new('script or http must not be defined for ttl checks')
           end
         elsif obj.key?("http")
           if (! obj.key?("interval"))
-            raise Puppet::ParseError('http must be defined for interval checks')
+            raise Puppet::ParseError.new('http must be defined for interval checks')
           end
         elsif obj.key?("script")
           if (! obj.key?("interval"))
-            raise Puppet::ParseError('script must be defined for interval checks')
+            raise Puppet::ParseError.new('script must be defined for interval checks')
           end
         else
-          raise Puppet::ParseError('One of ttl, script, or http must be defined.')
+          raise Puppet::ParseError.new('One of ttl, script, or http must be defined.')
         end
     else
-      raise Puppet::ParseError("Unable to handle object of type <%s>" % obj.class.to_s)
+      raise Puppet::ParseError.new("Unable to handle object of type <%s>" % obj.class.to_s)
   end
 end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -373,9 +373,9 @@ describe 'consul' do
 
     it { should contain_class('consul').with_init_style('debian') }
     it {
-      should contain_file('/etc/init.d/consul')
-        .with_content(/start-stop-daemon .* \$DAEMON/)
-        .with_content(/DAEMON_ARGS="agent/)
+      should contain_file('/etc/init.d/consul') \
+        .with_content(/start-stop-daemon .* \$DAEMON/) \
+        .with_content(/DAEMON_ARGS="agent/) \
         .with_content(/--user \$USER/)
     }
   end

--- a/spec/defines/consul_check_spec.rb
+++ b/spec/defines/consul_check_spec.rb
@@ -8,7 +8,9 @@ describe 'consul::check' do
     let(:params) {{}}
 
     it {
-      expect { should raise_error(Puppet::Error) }
+      expect {
+        should raise_error(Puppet::Error, /Wrong number of arguments/)
+      }
     }
   end
   describe 'with script' do
@@ -18,10 +20,10 @@ describe 'consul::check' do
     }}
     it {
       should contain_file("/etc/consul/check_my_check.json") \
-        .with_content(/"id" *: *"my_check"/)
-        .with_content(/"name" *: *"my_check"/)
-        .with_content(/"check" *: *{/)
-        .with_content(/"interval" *: *"30s"/)
+        .with_content(/"id" *: *"my_check"/) \
+        .with_content(/"name" *: *"my_check"/) \
+        .with_content(/"check" *: *\{/) \
+        .with_content(/"interval" *: *"30s"/) \
         .with_content(/"script" *: *"true"/)
     }
   end
@@ -33,11 +35,11 @@ describe 'consul::check' do
     }}
     it {
       should contain_file("/etc/consul/check_my_check.json") \
-        .with_content(/"id" *: *"my_check"/)
-        .with_content(/"name" *: *"my_check"/)
-        .with_content(/"check" *: *{/)
-        .with_content(/"interval" *: *"30s"/)
-        .with_content(/"script" *: *"true"/)
+        .with_content(/"id" *: *"my_check"/) \
+        .with_content(/"name" *: *"my_check"/) \
+        .with_content(/"check" *: *\{/) \
+        .with_content(/"interval" *: *"30s"/) \
+        .with_content(/"script" *: *"true"/) \
         .with_content(/"service_id" *: *"my_service"/)
     }
   end
@@ -48,11 +50,11 @@ describe 'consul::check' do
     }}
     it {
       should contain_file("/etc/consul/check_my_check.json") \
-        .with_content(/"id" *: *"my_check"/)
-        .with_content(/"name" *: *"my_check"/)
-        .with_content(/"check" *: *{/)
-        .with_content(/"interval" *: *"30s"/)
-        .with_content(/"http" *: *"localhost"/)
+        .with_content(/"id" *: *"my_check"/) \
+        .with_content(/"name" *: *"my_check"/) \
+        .with_content(/"check" *: *\{/) \
+        .with_content(/"interval" *: *"30s"/) \
+        .with_content(/"http" *: *"localhost"/) \
     }
   end
   describe 'with http and service_id' do
@@ -63,11 +65,11 @@ describe 'consul::check' do
     }}
     it {
       should contain_file("/etc/consul/check_my_check.json") \
-        .with_content(/"id" *: *"my_check"/)
-        .with_content(/"name" *: *"my_check"/)
-        .with_content(/"check" *: *{/)
-        .with_content(/"interval" *: *"30s"/)
-        .with_content(/"http" *: *"localhost"/)
+        .with_content(/"id" *: *"my_check"/) \
+        .with_content(/"name" *: *"my_check"/) \
+        .with_content(/"check" *: *\{/) \
+        .with_content(/"interval" *: *"30s"/) \
+        .with_content(/"http" *: *"localhost"/) \
         .with_content(/"service_id" *: *"my_service"/)
     }
   end
@@ -78,7 +80,7 @@ describe 'consul::check' do
     }}
     it {
       should contain_file("/etc/consul/check_my_check.json") \
-        .without_content(/"service_id"/)
+        .without_content(/"service_id"/) \
         .without_content(/"notes"/)
     }
   end
@@ -88,9 +90,9 @@ describe 'consul::check' do
     }}
     it {
       should contain_file("/etc/consul/check_my_check.json") \
-        .with_content(/"id" *: *"my_check"/)
-        .with_content(/"name" *: *"my_check"/)
-        .with_content(/"check" *: *{/)
+        .with_content(/"id" *: *"my_check"/) \
+        .with_content(/"name" *: *"my_check"/) \
+        .with_content(/"check" *: *\{/) \
         .with_content(/"ttl" *: *"30s"/)
     }
   end
@@ -101,10 +103,10 @@ describe 'consul::check' do
     }}
     it {
       should contain_file("/etc/consul/check_my_check.json") \
-        .with_content(/"id" *: *"my_check"/)
-        .with_content(/"name" *: *"my_check"/)
-        .with_content(/"check" *: *{/)
-        .with_content(/"ttl" *: *"30s"/)
+        .with_content(/"id" *: *"my_check"/) \
+        .with_content(/"name" *: *"my_check"/) \
+        .with_content(/"check" *: *\{/) \
+        .with_content(/"ttl" *: *"30s"/) \
         .with_content(/"service_id" *: *"my_service"/)
     }
   end
@@ -114,7 +116,7 @@ describe 'consul::check' do
       'interval' => '60s'
     }}
     it {
-      should raise_error(Puppet::Error)
+      should raise_error(Puppet::Error, /script or http must not be defined for ttl checks/)
     }
   end
   describe 'with both ttl and script' do
@@ -123,7 +125,7 @@ describe 'consul::check' do
       'script' => 'true'
     }}
     it {
-      should raise_error(Puppet::Error)
+      should raise_error(Puppet::Error, /script or http must not be defined for ttl checks/)
     }
   end
   describe 'with both ttl and http' do
@@ -132,7 +134,7 @@ describe 'consul::check' do
       'http' => 'http://localhost/health',
     }}
     it {
-      should raise_error(Puppet::Error)
+      should raise_error(Puppet::Error, /script or http must not be defined for ttl checks/)
     }
   end
   describe 'with both script and http' do
@@ -141,7 +143,7 @@ describe 'consul::check' do
       'http' => 'http://localhost/health',
     }}
     it {
-      should raise_error(Puppet::Error)
+      should raise_error(Puppet::Error, /script and http must not be defined together/)
     }
   end
   describe 'with script but no interval' do
@@ -149,7 +151,7 @@ describe 'consul::check' do
       'script' => 'true',
     }}
     it {
-      should raise_error(Puppet::Error)
+      should raise_error(Puppet::Error, /script must be defined for interval checks/)
     }
   end
   describe 'with http but no interval' do
@@ -157,7 +159,7 @@ describe 'consul::check' do
       'http' => 'http://localhost/health',
     }}
     it {
-      should raise_error(Puppet::Error)
+      should raise_error(Puppet::Error, /http must be defined for interval checks/)
     }
   end
   describe 'with a / in the id' do

--- a/spec/defines/consul_service_spec.rb
+++ b/spec/defines/consul_service_spec.rb
@@ -8,9 +8,9 @@ describe 'consul::service' do
     let(:params) {{}}
 
     it {
-      should contain_file("/etc/consul/service_my_service.json")
-        .with_content(/"service" *: *{/)
-        .with_content(/"id" *: *"my_service"/)
+      should contain_file("/etc/consul/service_my_service.json") \
+        .with_content(/"service" *: *\{/) \
+        .with_content(/"id" *: *"my_service"/) \
         .with_content(/"name" *: *"my_service"/)
     }
   end
@@ -19,7 +19,7 @@ describe 'consul::service' do
       'ensure' => 'absent',
     }}
     it {
-      should contain_file("/etc/consul/service_my_service.json")
+      should contain_file("/etc/consul/service_my_service.json") \
         .with('ensure' => 'absent')
     }
   end
@@ -29,9 +29,9 @@ describe 'consul::service' do
     }}
 
     it {
-      should contain_file("/etc/consul/service_my_service.json")
-        .with_content(/"service" *: *{/)
-        .with_content(/"id" *: *"my_service"/)
+      should contain_file("/etc/consul/service_my_service.json") \
+        .with_content(/"service" *: *\{/) \
+        .with_content(/"id" *: *"my_service"/) \
         .with_content(/"name" *: *"different_name"/)
     }
   end
@@ -42,10 +42,10 @@ describe 'consul::service' do
     }}
 
     it {
-      should contain_file("/etc/consul/service_my_service.json")
-        .with_content(/"service" *: *{/)
-        .with_content(/"id" *: *"my_service"/)
-        .with_content(/"name" *: *"different_name"/)
+      should contain_file("/etc/consul/service_my_service.json") \
+        .with_content(/"service" *: *\{/) \
+        .with_content(/"id" *: *"my_service"/) \
+        .with_content(/"name" *: *"different_name"/) \
         .with_content(/"address" *: *"127.0.0.1"/)
     }
   end
@@ -60,8 +60,8 @@ describe 'consul::service' do
     }}
     it {
       should contain_file("/etc/consul/service_my_service.json") \
-        .with_content(/"checks" *: *\[/)
-        .with_content(/"interval" *: *"30s"/)
+        .with_content(/"checks" *: *\[/) \
+        .with_content(/"interval" *: *"30s"/) \
         .with_content(/"script" *: *"true"/)
     }
   end
@@ -76,8 +76,8 @@ describe 'consul::service' do
     }}
     it {
       should contain_file("/etc/consul/service_my_service.json") \
-        .with_content(/"checks" *: *\[/)
-        .with_content(/"interval" *: *"30s"/)
+        .with_content(/"checks" *: *\[/) \
+        .with_content(/"interval" *: *"30s"/) \
         .with_content(/"http" *: *"localhost"/)
     }
   end
@@ -91,7 +91,7 @@ describe 'consul::service' do
     }}
     it {
       should contain_file("/etc/consul/service_my_service.json") \
-        .with_content(/"checks" *: *\[/)
+        .with_content(/"checks" *: *\[/) \
         .with_content(/"ttl" *: *"30s"/)
     }
   end
@@ -105,7 +105,9 @@ describe 'consul::service' do
       ]
     }}
     it {
-      expect { should raise_error(Puppet::Error) }
+      expect {
+        should raise_error(Puppet::Error, /script or http must not be defined for ttl checks/)
+      }
     }
   end
   describe 'with port' do
@@ -118,11 +120,11 @@ describe 'consul::service' do
       'port' => 5,
     }}
     it {
-      should contain_file("/etc/consul/service_my_service.json")
+      should contain_file("/etc/consul/service_my_service.json") \
         .with_content(/"port":5/)
     }
     it {
-      should_not contain_file("/etc/consul/service_my_service.json")
+      should_not contain_file("/etc/consul/service_my_service.json") \
         .with_content(/"port":"5"/)
     }
   end
@@ -136,7 +138,9 @@ describe 'consul::service' do
       ]
     }}
     it {
-      expect { should raise_error(Puppet::Error) }
+      expect {
+        should raise_error(Puppet::Error, /script or http must not be defined for ttl checks/)
+      }
     }
   end
   describe 'with interval but no script' do
@@ -148,7 +152,9 @@ describe 'consul::service' do
       ]
     }}
     it {
-      expect { should raise_error(Puppet::Error) }
+      expect {
+        should raise_error(Puppet::Error, /One of ttl, script or http must be defined/)
+      }
     }
   end
   describe 'with multiple checks script and http' do
@@ -166,10 +172,10 @@ describe 'consul::service' do
     }}
     it {
       should contain_file("/etc/consul/service_my_service.json") \
-        .with_content(/"checks" *: *\[/)
-        .with_content(/"interval" *: *"30s"/)
-        .with_content(/"script" *: *"true"/)
-        .with_content(/"interval" *: *"10s"/)
+        .with_content(/"checks" *: *\[/) \
+        .with_content(/"interval" *: *"30s"/) \
+        .with_content(/"script" *: *"true"/) \
+        .with_content(/"interval" *: *"10s"/) \
         .with_content(/"http" *: *"localhost"/)
     }
   end
@@ -186,7 +192,9 @@ describe 'consul::service' do
       ]
     }}
     it {
-      expect { should raise_error(Puppet::Error) }
+      expect {
+        should raise_error(Puppet::Error, /http must be defined for interval checks/)
+      }
     }
   end
 end

--- a/spec/defines/consul_watch_spec.rb
+++ b/spec/defines/consul_watch_spec.rb
@@ -77,7 +77,7 @@ describe 'consul::watch' do
     }}
     it {
       should contain_file('/etc/consul/watch_my_watch.json') \
-          .with_content(/"handler" *: *"handler_path"/)
+          .with_content(/"handler" *: *"handler_path"/) \
           .with_content(/"type" *: *"nodes"/)
     }
   end
@@ -92,7 +92,7 @@ describe 'consul::watch' do
     }}
     it {
       should contain_file('/etc/consul/watch_my_watch.json') \
-          .with_content(/"datacenter" *: *"dcName"/)
+          .with_content(/"datacenter" *: *"dcName"/) \
           .with_content(/"token" *: *"tokenValue"/)
     }
   end
@@ -117,7 +117,7 @@ describe 'consul::watch' do
         }}
         it {
           should contain_file('/etc/consul/watch_my_watch.json') \
-            .with_content(/"type" *: *"key"/)
+            .with_content(/"type" *: *"key"/) \
             .with_content(/"key" *: *"KeyName"/)
         }
       end
@@ -143,7 +143,7 @@ describe 'consul::watch' do
         }}
         it {
           should contain_file('/etc/consul/watch_my_watch.json') \
-            .with_content(/"type" *: *"keyprefix"/)
+            .with_content(/"type" *: *"keyprefix"/) \
             .with_content(/"prefix" *: *"keyPref"/)
         }
       end
@@ -169,7 +169,7 @@ describe 'consul::watch' do
         }}
         it {
           should contain_file('/etc/consul/watch_my_watch.json') \
-            .with_content(/"type" *: *"service"/)
+            .with_content(/"type" *: *"service"/) \
             .with_content(/"service" *: *"serviceName"/)
         }
       end
@@ -185,7 +185,7 @@ describe 'consul::watch' do
         }}
         it {
           should contain_file('/etc/consul/watch_my_watch.json') \
-            .with_content(/"tag" *: *"serviceTagName"/)
+            .with_content(/"tag" *: *"serviceTagName"/) \
             .with_content(/"passingonly" *: *true/)
         }
       end
@@ -213,7 +213,7 @@ describe 'consul::watch' do
         }}
         it {
           should contain_file('/etc/consul/watch_my_watch.json') \
-            .with_content(/"service" *: *"serviceName"/)
+            .with_content(/"service" *: *"serviceName"/) \
             .with_content(/"state" *: *"serviceState"/)
         }
       end


### PR DESCRIPTION
Fixes #148 

This adds ruby 1.8 support, which only involved changing the requirements in Gemfile and changing how exceptions are raised in consul_validate_checks.rb.