### PR TITLE
reload on service, checks and watch changes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -154,6 +154,9 @@ See the check.pp docstrings for all available inputs.
 You can also use `consul::checks` which accepts a hash of checks, and makes
 it easy to declare in hiera.
 
+## Removing Service, Check and Watch definitions
+Do `ensure => absent` while removing existing service, check and watch definitions. This ensures consul will be reloaded via `SIGHUP`. If you have `purge_config_dir` set to `true` and simply remove the definition it will cause consul to restart.
+
 ## ACL Definitions
 
 ```puppet

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -5,6 +5,10 @@
 #
 # == Parameters
 #
+# [*ensure*]
+#   Define availability of check. Use 'absent' to remove existing checks.
+#   Defaults to 'present'
+#
 # [*id*]
 #   The id for the check (defaults to $title)
 #
@@ -35,6 +39,7 @@
 #   ACL token for interacting with the catalog (must be 'management' type)
 #
 define consul::check(
+  $ensure     = present,
   $id         = $title,
   $ttl        = undef,
   $http       = undef,
@@ -69,6 +74,7 @@ define consul::check(
   $escaped_id = regsubst($id,'\/','_')
   File[$consul::config_dir] ->
   file { "${consul::config_dir}/check_${escaped_id}.json":
+    ensure  => $ensure,
     content => template('consul/check.json.erb'),
-  } ~> Class['consul::run_service']
+  } ~> Class['consul::reload_service']
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -107,6 +107,7 @@ class consul::config(
     recurse => $purge,
   } ->
   file { 'consul config.json':
+    ensure  => present,
     path    => "${consul::config_dir}/config.json",
     content => consul_sorted_json(merge($config_hash,$bootstrap_expect_hash,$protocol_hash)),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,7 +128,7 @@ class consul (
     config_hash => $config_hash_real,
     purge       => $purge_config_dir,
   } ~>
-  class { 'consul::run_service': }
-  ->
+  class { 'consul::run_service': } ->
+  class { 'consul::reload_service': } ->
   anchor {'consul_last': }
 }

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -1,0 +1,16 @@
+# == Class consul::reload_service
+#
+# This class is meant to be called from certain
+# configuration changes that support reload.
+#
+# https://www.consul.io/docs/agent/options.html#reloadable-configuration
+#
+class consul::reload_service {
+
+  exec { 'reload consul service':
+    path        => [$consul::bin_dir,'/bin','/usr/bin'],
+    command     => 'consul reload',
+    refreshonly => true,
+  }
+
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -31,7 +31,7 @@
 #   ACL token for interacting with the catalog (must be 'management' type)
 #
 define consul::service(
-  $ensure         = 'present',
+  $ensure         = present,
   $service_name   = $title,
   $id             = $title,
   $tags           = [],
@@ -70,5 +70,5 @@ define consul::service(
     ensure  => $ensure,
     content => consul_sorted_json($service_hash),
     require => File[$consul::config_dir],
-  } ~> Class['consul::run_service']
+  } ~> Class['consul::reload_service']
 }

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -5,6 +5,10 @@
 #
 # == Parameters
 #
+# [*ensure*]
+#   Define availability of watch. Use 'absent' to remove existing watches.
+#   Defaults to 'present'
+#
 # [*handler*]
 #   Full path to the script that will be excuted.
 #
@@ -40,6 +44,7 @@
 #   Name of an event to watch for.
 #
 define consul::watch(
+  $ensure       = present,
   $handler      = undef,
   $datacenter   = undef,
   $token        = undef,
@@ -130,6 +135,7 @@ define consul::watch(
 
   File[$consul::config_dir] ->
   file { "${consul::config_dir}/watch_${id}.json":
+    ensure  => $ensure,
     content => template('consul/watch.json.erb'),
-  } ~> Class['consul::run_service']
+  } ~> Class['consul::reload_service']
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -45,6 +45,10 @@ describe 'consul' do
     it { should contain_class('consul::config').with(:purge => false) }
   end
 
+  context 'consul::config should notify consul::run_service' do
+    it { should contain_class('consul::config').that_notifies(['Class[consul::run_service]']) }
+  end
+
   context 'When joining consul to a wan cluster by a known URL' do
     let(:params) {{
         :join_wan => 'wan_host.test.com'

--- a/spec/defines/consul_check_spec.rb
+++ b/spec/defines/consul_check_spec.rb
@@ -43,7 +43,7 @@ describe 'consul::check' do
         .with_content(/"service_id" *: *"my_service"/)
     }
   end
-  describe 'with script and token' do
+  describe 'reload service with script and token' do
     let(:params) {{
       'interval' => '30s',
       'script'   => 'true',
@@ -56,6 +56,7 @@ describe 'consul::check' do
         .with_content(/"interval" *: *"30s"/) \
         .with_content(/"script" *: *"true"/) \
         .with_content(/"token" *: *"too-cool-for-this-script"/) \
+        .that_notifies("Class[consul::reload_service]") \
     }
   end
   describe 'with http' do
@@ -88,7 +89,7 @@ describe 'consul::check' do
         .with_content(/"service_id" *: *"my_service"/)
     }
   end
-  describe 'with http and token' do
+  describe 'reload service with http and token' do
     let(:params) {{
       'interval' => '30s',
       'http'     => 'localhost',
@@ -101,6 +102,7 @@ describe 'consul::check' do
         .with_content(/"interval" *: *"30s"/) \
         .with_content(/"http" *: *"localhost"/) \
         .with_content(/"token" *: *"too-cool-for-this-http"/) \
+        .that_notifies("Class[consul::reload_service]") \
     }
   end
   describe 'with http and removed undef values' do
@@ -140,7 +142,7 @@ describe 'consul::check' do
         .with_content(/"service_id" *: *"my_service"/)
     }
   end
-  describe 'with ttl and token' do
+  describe 'reload service with ttl and token' do
     let(:params) {{
       'ttl'   => '30s',
       'token' => 'too-cool-for-this-ttl'
@@ -151,6 +153,7 @@ describe 'consul::check' do
         .with_content(/"name" *: *"my_check"/) \
         .with_content(/"ttl" *: *"30s"/) \
         .with_content(/"token" *: *"too-cool-for-this-ttl"/) \
+        .that_notifies("Class[consul::reload_service]") \
     }
   end
   describe 'with both ttl and interval' do

--- a/spec/defines/consul_service_spec.rb
+++ b/spec/defines/consul_service_spec.rb
@@ -23,6 +23,12 @@ describe 'consul::service' do
         .with('ensure' => 'absent')
     }
   end
+  describe 'notify reload service' do
+    it {
+      should contain_file("/etc/consul/service_my_service.json") \
+        .that_notifies('Class[consul::reload_service]')
+    }
+  end
   describe 'with service name' do
     let(:params) {{
       'service_name' => 'different_name',

--- a/spec/defines/consul_watch_spec.rb
+++ b/spec/defines/consul_watch_spec.rb
@@ -279,4 +279,14 @@ describe 'consul::watch' do
 
   end
 
+  describe 'notify reload service' do
+    let (:params) {{
+      'type' => 'nodes',
+      'handler' => 'handler_path',
+    }}
+    it {
+      should contain_file('/etc/consul/watch_my_watch.json') \
+          .that_notifies("Class[consul::reload_service]") \
+    }
+  end
 end


### PR DESCRIPTION
Certain config changes can trigger a reload by sending `SIGHUP` signal (which `consul reload` essentially does). I implemented reload for services, checks and watches although more are supported.

Also confirmed while adding, modifying and removing these resources consul PID remained unchanged throughout.

https://www.consul.io/docs/commands/reload.html
https://www.consul.io/docs/agent/options.html#reloadable-configuration