### PR TITLE
travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
+sudo: false
 rvm:
   - 1.8.7
   - 1.9.3
@@ -11,15 +12,10 @@ script: bundle exec rake test
 env:
   - PUPPET_VERSION="~> 2.7.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.1.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.2.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.3.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.4.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.4" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.1.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.1.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 3.7.4" FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 4.0.0"
+  - PUPPET_VERSION="~> 4.1.0"
 matrix:
   exclude:
   - rvm: 1.9.3


### PR DESCRIPTION
In an effort to speed up travis testing:
Removed some intermediate puppet versions that weren't in PE
Enabled travis's container-based testing
FUTURE_PARSER also includes STRICT_VARIABLES (and neither parameter exists in 4.x)

In all the travis tests I've watched run errors are typically either on all tests, old version of ruby, or future parser/strict_variables.  Testing every version seemed like it just made things take longer without any real benefit, your experience may be different though.  (I'd also vote to drop 2.7 testing/support - it's 2 major versions behind)