### PR TITLE
Correct sysv init script to check if sockets are free. This solve pro…

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,8 +13,28 @@
 class consul::config(
   $config_hash,
   $purge = true,
+  $port_hash = undef,
 ) {
-
+  $port_hash_default = {
+    'dns'      => 8600,
+    'http'     => 8500,
+    'https'    => -1,
+    'rpc'      => 8400,
+    'serf_lan' => 8301,
+    'serf_wan' => 8302,
+    'server'   => 8300,
+  }
+  $config_ports_not_int = merge($port_hash_default, $port_hash)
+  $config_ports={
+    'dns'      => $config_ports_not_int['dns'] * 1,
+    'http'     => $config_ports_not_int['http'] * 1,
+    'https'    => $config_ports_not_int['https'] * 1,
+    'rpc'      => $config_ports_not_int['rpc'] * 1,
+    'serf_lan' => $config_ports_not_int['serf_lan'] * 1,
+    'serf_wan' => $config_ports_not_int['serf_wan'] * 1,
+    'server'   => $config_ports_not_int['server'] * 1,
+  }
+  validate_hash($config_ports)
   if $consul::init_style {
 
     case $consul::init_style {

--- a/templates/consul.sysv.erb
+++ b/templates/consul.sysv.erb
@@ -12,11 +12,13 @@
 
 # Source function library.
 . /etc/init.d/functions
-
+<% config_ports = scope.lookupvar('consul::config::config_ports') -%>
 CONSUL=<%= scope.lookupvar('consul::bin_dir') %>/consul
 CONFIG=<%= scope.lookupvar('consul::config_dir') %>
 PID_FILE=/var/run/consul/consul.pid
 LOG_FILE=/var/log/consul
+RETRY=240
+SS_BIN=`which ss`
 
 [ -e /etc/sysconfig/consul ] && . /etc/sysconfig/consul
 
@@ -64,8 +66,18 @@ stop() {
         # If consul is not acting as a server, exit gracefully
         if ("${CONSUL}" info 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
             "$CONSUL" leave
-        fi
-
+	fi
+        <% first_loop=0 %>
+        for (( i=1; i<=$RETRY; i++ ))
+	do
+	    if [ "`$SS_BIN -nao '( <% config_ports.keys.sort.each do |key| -%><% if config_ports[key] > 0 %><% if first_loop == 0 %>sport = :<%=config_ports[key]-%><% first_loop=1 %><% else %> or sport = :<%=config_ports[key]-%><% end %><% end %><% end -%> )' | wc -l`" -gt 1 ];
+	    then
+	        /bin/echo "Waiting one more second to stop consul (check $i) "
+	       /bin/sleep 1
+	   else
+	      break
+	   fi
+	done	
         # If acting as a server, or if leave failed, kill it.
         mkpidfile
         killproc $KILLPROC_OPT $CONSUL -9


### PR DESCRIPTION
…blem during restart when old process stop but sockets are still in use and then new one can't start.
I found that consul agent after stop sometimes is leaving open connection which can last for me up to 45 seconds (this is the highest value which I found during tests). This fix is solving the problem by adding the loop which check if sockets are free and after that is finishing stop function in init script. So when we try to start again we are sure that process will not crash.