### PR TITLE
UI dir symlink should depend on the dist existing

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -42,7 +42,7 @@ class consul::install {
           source  => $consul::real_ui_download_url,
           target  => "${consul::data_dir}/${consul::version}_web_ui",
           creates => "${consul::data_dir}/${consul::version}_web_ui/dist",
-        }
+        } ->
         file { $consul::ui_dir:
           ensure => 'symlink',
           target => "${consul::data_dir}/${consul::version}_web_ui/dist",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -134,6 +134,7 @@ describe 'consul' do
     }}
     it { should contain_staging__file('consul_web_ui.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.5.2_web_ui.zip') }
     it { should contain_file('/dir1/dir2').that_requires('Staging::Deploy[consul_web_ui.zip]') }
+    it { should contain_file('/dir1/dir2').with(:ensure => 'symlink') }
   end
 
   context "When installing UI via URL by with a special version" do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -133,6 +133,7 @@ describe 'consul' do
       },
     }}
     it { should contain_staging__file('consul_web_ui.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.5.2_web_ui.zip') }
+    it { should contain_file('/dir1/dir2').that_requires('Staging::Deploy[consul_web_ui.zip]') }
   end
 
   context "When installing UI via URL by with a special version" do


### PR DESCRIPTION
I've had some issues with the ui dir symlink when trying to set the data dir to a path on an LVM volume that doesn't (yet) exist.

Even with `Lvm::Volume_group <||> -> Class['consul']` the symlink creation fails. Which has me a little baffled.

Either way, this fix is trivial and probably makes sense to delay the symlink creation anyhow!


Trace:
```
(/Stage[main]/Staging/File[/opt/staging]/ensure) created
(/Stage[main]/Consul::Install/Staging::File[consul.zip]/File[/opt/staging/consul]/ensure) created
(/Stage[main]/Consul::Install/Staging::File[consul.zip]/Exec[/opt/staging/consul/consul.zip]/returns) executed successfully
(/Stage[main]/Consul::Install/Group[consul]/ensure) created
Could not set 'link' on ensure: No such file or directory - /var/consul at 49:/etc/puppet/modules/consul/manifests/install.pp
Could not set 'link' on ensure: No such file or directory - /var/consul at 49:/etc/puppet/modules/consul/manifests/install.pp
Wrapped exception:
No such file or directory - /var/consul
(/Stage[main]/Consul::Install/File[/var/consul/ui]/ensure) change from absent to link failed: Could not set 'link' on ensure: No such file or directory - /var/consul at 49:/etc/puppet/modules/consul/manifests/install.pp
```