### PR TITLE
[install] use data_dir from config_hash

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,7 +123,10 @@ class consul (
 
   anchor {'consul_first': }
   ->
-  class { 'consul::install': } ->
+  class { 'consul::install':
+    data_dir => $config_hash_real['data_dir'],
+  }
+  ->
   class { 'consul::config':
     config_hash => $config_hash_real,
     purge       => $purge_config_dir,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,10 +2,12 @@
 #
 # Installs consule based in the parameters from init
 #
-class consul::install {
+class consul::install (
+  $data_dir = undef,
+  ){
 
-  if $consul::data_dir {
-    file { $consul::data_dir:
+  if $data_dir {
+    file { $data_dir:
       ensure => 'directory',
       owner  => $consul::user,
       group  => $consul::group,


### PR DESCRIPTION
the data_dir variable in install.pp appears to be unused making it
impossible to change the owner of the data_dir directory. This makes it possible to change the owner of the data_dir, as well as force consistency with the configuration.