### PR TITLE
Ensure all network interfaces are up before starting in upstart config

### DIFF
--- a/templates/consul.upstart.erb
+++ b/templates/consul.upstart.erb
@@ -1,6 +1,6 @@
 # Consul Agent (Upstart unit)
 description "Consul Agent"
-start on (local-filesystems and net-device-up IFACE!=lo)
+start on runlevel [2345]
 stop on runlevel [06]
 
 env CONSUL=<%= scope.lookupvar('consul::bin_dir') %>/consul


### PR DESCRIPTION
The previous approach is problematic when there are multiple interfaces on the host and consul is bound to only one, resulting in errors like

    ==> Error starting agent: Failed to start Consul server: Failed to start RPC layer: listen tcp 10.0.2.15:8300: bind: cannot assign requested address

Despite what http://upstart.ubuntu.com/cookbook/#normal-start says, this is the preferred approach as elaborated on at https://lists.debian.org/debian-devel/2013/08/msg00686.html. https://github.com/hashicorp/consul/blob/master/terraform/aws/scripts/ubuntu/upstart.conf takes the same approach as well.