### PR TITLE
Fix url upgrade and downgrade

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,9 +73,8 @@ class consul (
 ) inherits consul::params {
 
   $real_download_file = "${version}_${os}_${arch}.${download_extension}"
-  $real_ui_download_file = "${version}_web_ui.${ui_download_extension}"
   $real_download_url    = pick($download_url, "${download_url_base}${real_download_file}")
-  $real_ui_download_url = pick($ui_download_url, "${ui_download_url_base}${real_ui_download_file}")
+  $real_ui_download_url = pick($ui_download_url, "${ui_download_url_base}${version}_web_ui.${ui_download_extension}")
 
   validate_bool($purge_config_dir)
   validate_bool($manage_user)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,8 +72,10 @@ class consul (
   $acls                  = {},
 ) inherits consul::params {
 
-  $real_download_url    = pick($download_url, "${download_url_base}${version}_${os}_${arch}.${download_extension}")
-  $real_ui_download_url = pick($ui_download_url, "${ui_download_url_base}${version}_web_ui.${ui_download_extension}")
+  $real_download_file = "${version}_${os}_${arch}.${download_extension}"
+  $real_ui_download_file = "${version}_web_ui.${ui_download_extension}"
+  $real_download_url    = pick($download_url, "${download_url_base}${real_download_file}")
+  $real_ui_download_url = pick($ui_download_url, "${ui_download_url_base}${real_ui_download_file}")
 
   validate_bool($purge_config_dir)
   validate_bool($manage_user)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,8 +27,9 @@ class consul::install {
       ##  after it gets some patchwork and closer to release version
       #
       # Puppetversion fact has to be in quotes due to versioncmp differences between Puppet 3.x and 4.x
+      $puppet_version = inline_template("<%= Facter.value('puppetversion').to_s %>")
       # This was done for puppet 3.x not supporting Ubuntu 15 and Fedora 22, and since this ruby line doesn't support site.pp... override of Service { provider => 'systemd' }
-      if versioncmp("${::puppetversion}", 4.2) < 0 {
+      if versioncmp($puppet_version, 4.2) < 0 {
         $ruby_service_stop = $::operatingsystem ? {
           'fedora' => "ruby -r 'puppet' -e \"Puppet::Type.type(:service).newservice(:name => 'consul', :provider => '${consul::init_style}').provider.send('stop')\"",
           'ubuntu' => "ruby -r 'puppet' -e \"Puppet::Type.type(:service).newservice(:name => 'consul', :provider => '${consul::init_style}').provider.send('stop')\"",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,13 +26,13 @@ class consul::install {
       } ->
       staging::extract { "${consul::real_download_file}":
         target         => $consul::bin_dir,
-        onlyif         => "test `consul version | grep -m1 -o [0-9\\.] | tr -d '\\n'` != ${consul::version}; unlessval=$?; if [ \$unlessval = 0 ]; then rm -f ${consul::bin_dir}/consul; fi; test \$unlessval = 0",
+        unless         => "which consul > /dev/null ; if [ $? = 0 ]; then test `consul version | grep -m1 -o [0-9\\.] | tr -d '\\n'` = ${consul::version}; unlessval=$?; if [ \$unlessval = 1 ]; then rm -f ${consul::bin_dir}/consul; fi; else unlessval=1; fi; test \$unlessval = 0",
       } ->
       file { "${consul::bin_dir}/consul":
         owner => 'root',
         group => 0, # 0 instead of root because OS X uses "wheel".
         mode  => '0555',
-      } ~> Service['consul']
+      } ~> Class['consul::run_service']
 
       if ($consul::ui_dir and $consul::data_dir) {
         if $::operatingsystem != 'darwin' {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,10 +26,8 @@ class consul::install {
       ## Suggest moving to using puppetlabs-transition module to do the service work
       ##  after it gets some patchwork and closer to release version
       #
-      # Puppetversion fact has to be in quotes due to versioncmp differences between Puppet 3.x and 4.x
-      $puppet_version = inline_template("<%= Facter.value('puppetversion').to_s %>")
       # This was done for puppet 3.x not supporting Ubuntu 15 and Fedora 22, and since this ruby line doesn't support site.pp... override of Service { provider => 'systemd' }
-      if versioncmp($puppet_version, 4.2) < 0 {
+      if $::puppetversion =~ /^4/ {
         $ruby_service_stop = $::operatingsystem ? {
           'fedora' => "ruby -r 'puppet' -e \"Puppet::Type.type(:service).newservice(:name => 'consul', :provider => '${consul::init_style}').provider.send('stop')\"",
           'ubuntu' => "ruby -r 'puppet' -e \"Puppet::Type.type(:service).newservice(:name => 'consul', :provider => '${consul::init_style}').provider.send('stop')\"",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,8 +26,9 @@ class consul::install {
       ## Suggest moving to using puppetlabs-transition module to do the service work
       ##  after it gets some patchwork and closer to release version
       #
+      # Puppetversion fact has to be in quotes due to versioncmp differences between Puppet 3.x and 4.x
       # This was done for puppet 3.x not supporting Ubuntu 15 and Fedora 22, and since this ruby line doesn't support site.pp... override of Service { provider => 'systemd' }
-      if versioncmp($::puppetversion, 4.2) < 0 {
+      if versioncmp("${::puppetversion}", 4.2) < 0 {
         $ruby_service_stop = $::operatingsystem ? {
           'fedora' => "ruby -r 'puppet' -e \"Puppet::Type.type(:service).newservice(:name => 'consul', :provider => '${consul::init_style}').provider.send('stop')\"",
           'ubuntu' => "ruby -r 'puppet' -e \"Puppet::Type.type(:service).newservice(:name => 'consul', :provider => '${consul::init_style}').provider.send('stop')\"",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,13 +15,17 @@ class consul::install {
 
   case $consul::install_method {
     'url': {
-      # This is done just so we can take a look at what staging path it wants to use, if we remove this, we have to completely assume or manage the staging path
+      # This is done just so we can take a look at what staging path it wants to use.
+      # If we remove this, we have to completely assume or manage the staging path
       include staging
 
       if $::operatingsystem != 'darwin' {
-        ensure_packages(['unzip'], { 'before' => Staging::File['consul.zip'] })
+        ensure_packages(['unzip'], { 'before' => Staging::File[$consul::real_download_file] })
       }
 
+      ## Suggest moving to using puppetlabs-transition module to do the service work
+      ##  after it gets some patchwork and closer to release version
+      #
       # This was done for puppet 3.x not supporting Ubuntu 15 and Fedora 22, and since this ruby line doesn't support site.pp... override of Service { provider => 'systemd' }
       if versioncmp($::puppetversion, 4.2) < 0 {
         $ruby_service_stop = $::operatingsystem ? {
@@ -40,12 +44,12 @@ class consul::install {
       } else {
         $clean_staging_dir = "find /opt/staging/consul ! -name '${consul::real_download_file}' -type f -exec rm -f {} +"
       }
-      staging::file { "${consul::real_download_file}":
+      staging::file { $consul::real_download_file:
         source => $consul::real_download_url
       } ->
-      staging::extract { "${consul::real_download_file}":
-        target         => $consul::bin_dir,
-        unless         => "which consul > /dev/null ; if [ $? = 0 ]; then test `consul version | grep -m1 -o [0-9\\.] | tr -d '\\n'` = ${consul::version}; unlessval=$?; if [ \$unlessval = 1 ]; then ${clean_staging_dir}; ${ruby_service_stop}; rm -f ${consul::bin_dir}/consul; fi; else unlessval=1; fi; test \$unlessval = 0",
+      staging::extract { $consul::real_download_file:
+        target => $consul::bin_dir,
+        unless => "which consul > /dev/null ; if [ $? = 0 ]; then test `consul version | grep -m1 -o [0-9\\.] | tr -d '\\n'` = ${consul::version}; unlessval=$?; if [ \$unlessval = 1 ]; then ${clean_staging_dir}; ${ruby_service_stop}; rm -f ${consul::bin_dir}/consul; fi; else unlessval=1; fi; test \$unlessval = 0",
       } ->
       file { "${consul::bin_dir}/consul":
         owner => 'root',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,7 +15,9 @@ class consul::install {
 
   case $consul::install_method {
     'url': {
+      # This is done just so we can take a look at what staging path it wants to use, if we remove this, we have to completely assume or manage the staging path
       include staging
+
       if $::operatingsystem != 'darwin' {
         ensure_packages(['unzip'], { 'before' => Staging::File['consul.zip'] })
       }
@@ -38,10 +40,6 @@ class consul::install {
       } else {
         $clean_staging_dir = "find /opt/staging/consul ! -name '${consul::real_download_file}' -type f -exec rm -f {} +"
       }
-      # This was done to make it so we don't have to do absolute paths in our unless inside staging::extract, since that module doesn't allow us to pass path => to it.
-      Exec {
-        provider => shell
-      } 
       staging::file { "${consul::real_download_file}":
         source => $consul::real_download_url
       } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,13 +28,13 @@ class consul::install {
       #
       # This was done for puppet 3.x not supporting Ubuntu 15 and Fedora 22, and since this ruby line doesn't support site.pp... override of Service { provider => 'systemd' }
       if $::puppetversion =~ /^4/ {
+        $ruby_service_stop = "ruby -r 'puppet' -e \"Puppet::Type.type(:service).newservice(:name => 'consul').provider.send('stop')\""
+      } else {
         $ruby_service_stop = $::operatingsystem ? {
           'fedora' => "ruby -r 'puppet' -e \"Puppet::Type.type(:service).newservice(:name => 'consul', :provider => '${consul::init_style}').provider.send('stop')\"",
           'ubuntu' => "ruby -r 'puppet' -e \"Puppet::Type.type(:service).newservice(:name => 'consul', :provider => '${consul::init_style}').provider.send('stop')\"",
           default  => "ruby -r 'puppet' -e \"Puppet::Type.type(:service).newservice(:name => 'consul').provider.send('stop')\""
         }
-      } else {
-        $ruby_service_stop = "ruby -r 'puppet' -e \"Puppet::Type.type(:service).newservice(:name => 'consul').provider.send('stop')\""
       }
       # I don't trust mistakes in $staging::path as if it was set to / then this find would delete everything except that one file all the way from the root path /
       # And since we're only supporting Linux and Darwin(Mac) in this current revision of this puppet-consul module.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "KyleAnderson-consul",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Kyle Anderson <kyle@xkyle.com>",
   "summary": "Configures Consul by Hashicorp",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,6 +9,7 @@ describe 'consul' do
       :osfamily               => 'Debian',
       :operatingsystemrelease => '10.04',
       :kernel                 => 'Linux',
+      :puppetversion          => ENV['PUPPET_VERSION'],
     }
   end
   # Installation Stuff

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -61,7 +61,10 @@ describe 'consul' do
   end
 
   context 'Require unzip package when installing via URL' do
-    it { should contain_staging__file('consul.zip').that_requires('Package[unzip]') }
+    let(:params) {{
+      :version   => '0.5.2',
+    }}
+    it { should contain_staging__file('0.5.2_linux_amd64.zip').that_requires('Package[unzip]') }
   end
 
   context "Require unzip package when installing UI via URL" do
@@ -96,21 +99,25 @@ describe 'consul' do
   end
 
   context "When installing via URL by default" do
-    it { should contain_staging__file('consul.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip') }
+    let(:params) {{
+      :version   => '0.5.2',
+    }}
+    it { should contain_staging__file('0.5.2_linux_amd64.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip') }
   end
 
   context "When installing via URL by with a special version" do
     let(:params) {{
       :version   => '42',
     }}
-    it { should contain_staging__file('consul.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/42_linux_amd64.zip') }
+    it { should contain_staging__file('42_linux_amd64.zip').with(:source => 'https://dl.bintray.com/mitchellh/consul/42_linux_amd64.zip') }
   end
 
   context "When installing via URL by with a custom url" do
     let(:params) {{
       :download_url   => 'http://myurl',
+      :version   => '0.5.2',
     }}
-    it { should contain_staging__file('consul.zip').with(:source => 'http://myurl') }
+    it { should contain_staging__file('0.5.2_linux_amd64.zip').with(:source => 'http://myurl') }
   end
 
 
@@ -140,7 +147,7 @@ describe 'consul' do
     }}
     it { should_not contain_package('consul') }
     it { should_not contain_package('consul_ui') }
-    it { should_not contain_staging__file('consul.zip') }
+    it { should_not contain_staging__file('0.5.2_linux_amd64.zip') }
     it { should_not contain_staging__file('consul_web_ui.zip') }
   end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,7 +9,6 @@ describe 'consul' do
       :osfamily               => 'Debian',
       :operatingsystemrelease => '10.04',
       :kernel                 => 'Linux',
-      :puppetversion          => ENV['PUPPET_VERSION'],
     }
   end
   # Installation Stuff


### PR DESCRIPTION
This would allow support of upgrading and downgrading via URL method.  Version would be a required parameter only to upgrade or downgrade, if not supplied the file will just be for example, '_redhat_amd64.zip', not an issue.

I have had talks with puppetlabs devs and puppetlabs-transition module is meant to help with this but it is still version 0.1.0 and I haven't seen it be maintained since earlier this year; so in the mean time I decided to go with the ruby calls.  I haven't tested yet if the transition module supports overrides like:
Service { provider => 'systemd' } or not.  In this current iteration I've not put support in here for it either, only conditional logic to support init_style changing the provider on the ruby call in the case of two unsupported distros in puppet 3.x
I accept discussions on this of course.  We can also instead of a ruby call, use the slightly slower call of:
puppet resource service consul provider=systemd ensure=stopped

Cheers,

Adam