### PR TITLE
explicitly define ownership of config directory, installation breaks for hardened Linux boxes with default umask of 0077 - this fixes the problem

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -86,6 +86,8 @@ class consul::config(
 
   file { $consul::config_dir:
     ensure  => 'directory',
+    owner   => $consul::user,
+    group   => $consul::group,
     purge   => $purge,
     recurse => $purge,
   } ->


### PR DESCRIPTION
Hi there @solarkennedy, just a small fix to persmission problems on systems using umask 0077 as default.

<img width="787" alt="screen shot 2015-08-14 at 8 01 24 am" src="https://cloud.githubusercontent.com/assets/2142512/9264941/f04fb7f8-425e-11e5-9473-b74a73c944d3.png">
