### PR TITLE
parameterize restart on change for the main config

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -49,6 +49,13 @@ describe 'consul' do
     it { should contain_class('consul::config').that_notifies(['Class[consul::run_service]']) }
   end
 
+  context 'consul::config should not notify consul::run_service on config change' do
+    let(:params) {{
+      :restart_on_change => false
+    }}
+    it { should_not contain_class('consul::config').that_notifies(['Class[consul::run_service]']) }
+  end
+
   context 'When joining consul to a wan cluster by a known URL' do
     let(:params) {{
         :join_wan => 'wan_host.test.com'


### PR DESCRIPTION
This will allow us to restart the agent conditionally when `$config_hash` changes. This does not affect reloads when service, check and watch configs change.

It defaults to the current behavior of restarting on config change.

In my experience its never a good idea for puppet to restart consul `server`. More often than not you will run into a situation where the cluster doesn't know who the leader is. Its best to restart the agent on server in a more controlled fashion.