### PR TITLE
deep_merge to support nested objects

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,7 +86,7 @@ class consul (
   validate_hash($checks)
   validate_hash($acls)
 
-  $config_hash_real = merge($config_defaults, $config_hash)
+  $config_hash_real = deep_merge($config_defaults, $config_hash)
   validate_hash($config_hash_real)
 
   if $config_hash_real['data_dir'] {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -243,15 +243,24 @@ describe 'consul' do
       :config_defaults => {
           'data_dir' => '/dir1',
           'server' => false,
+          'ports' => {
+            'http' => 1,
+          },
       },
       :config_hash => {
           'bootstrap_expect' => '5',
           'server' => true,
+          'ports' => {
+            'http'  => -1,
+            'https' => 8500,
+          },
       }
     }}
     it { should contain_file('consul config.json').with_content(/"bootstrap_expect":5/) }
     it { should contain_file('consul config.json').with_content(/"data_dir":"\/dir1"/) }
     it { should contain_file('consul config.json').with_content(/"server":true/) }
+    it { should contain_file('consul config.json').with_content(/"http":-1/) }
+    it { should contain_file('consul config.json').with_content(/"https":8500/) }
   end
 
   context "When asked not to manage the user" do


### PR DESCRIPTION
Updated to use `deep_merge` to support nested hashes.

Consul has 2 nested objects, [addresses](https://www.consul.io/docs/agent/options.html#addresses) and [ports](https://www.consul.io/docs/agent/options.html#ports) and the `merge` function doesn't properly merge nested hashes.