### PR TITLE
Add a check for $service_ensure in reload_service

### DIFF
--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -9,7 +9,7 @@ class consul::reload_service {
 
   # Don't attempt to reload if we're not supposed to be running.
   # This can happen during pre-provisioning of a node.
-  if $::consul::service_ensure != 'stopped' {
+  if $consul::manage_service == true and $consul::service_ensure == 'running' {
     exec { 'reload consul service':
       path        => [$consul::bin_dir,'/bin','/usr/bin'],
       command     => 'consul reload',

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -7,10 +7,14 @@
 #
 class consul::reload_service {
 
-  exec { 'reload consul service':
-    path        => [$consul::bin_dir,'/bin','/usr/bin'],
-    command     => 'consul reload',
-    refreshonly => true,
+  # Don't attempt to reload if we're not supposed to be running.
+  # This can happen during pre-provisioning of a node.
+  if $::consul::service_ensure != 'stopped' {
+    exec { 'reload consul service':
+      path        => [$consul::bin_dir,'/bin','/usr/bin'],
+      command     => 'consul reload',
+      refreshonly => true,
+    }
   }
 
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -270,6 +270,30 @@ describe 'consul' do
     it { should_not contain_service('consul') }
   end
 
+  context "When a reload_service is triggered with service_ensure stopped" do
+    let (:params) {{
+      :service_ensure => 'stopped',
+      :services => {
+        'test_service1' => {
+          'port' => '5'
+        }
+      }
+    }}
+    it { should_not contain_exec('reload consul service')  }
+  end
+
+  context "When a reload_service is triggered with manage_service false" do
+    let (:params) {{
+      :manage_service => false,
+      :services => {
+        'test_service1' => {
+          'port' => '5'
+        }
+      }
+    }}
+    it { should_not contain_exec('reload consul service')  }
+  end
+
   context "With a custom username" do
     let(:params) {{
       :user => 'custom_consul_user',
@@ -291,6 +315,7 @@ describe 'consul' do
     }}
     it { should contain_consul__service('test_service1').with_port('5') }
     it { should have_consul__service_resource_count(1) }
+    it { should contain_exec('reload consul service')  }
   end
 
   context "When the user provides a hash of watches" do
@@ -305,6 +330,7 @@ describe 'consul' do
     it { should contain_consul__watch('test_watch1').with_type('nodes') }
     it { should contain_consul__watch('test_watch1').with_handler('test.sh') }
     it { should have_consul__watch_resource_count(1) }
+    it { should contain_exec('reload consul service')  }
   end
 
   context "When the user provides a hash of checks" do
@@ -319,6 +345,7 @@ describe 'consul' do
     it { should contain_consul__check('test_check1').with_interval('30') }
     it { should contain_consul__check('test_check1').with_script('test.sh') }
     it { should have_consul__check_resource_count(1) }
+    it { should contain_exec('reload consul service')  }
   end
 
   context "With multiple watches and a config hash for #83" do
@@ -348,6 +375,7 @@ describe 'consul' do
     }}
     it { should contain_consul__watch('services') }
     it { should have_consul__watch_resource_count(3) }
+    it { should contain_exec('reload consul service')  }
   end
 
   context "On a redhat 6 based OS" do


### PR DESCRIPTION
When pre-provisioning a node with a tool like Packer (https://packer.io)
it's possible that we're only installing using Puppet, not attempting to
run a live configuration.  "reload_service" didn't respect the setting
of $service_ensure, so it would attempt to reload the consul config even
if the service was supposed to be stopped.

In a pre-provisioning case, the Consul config may be populated with
place-holders for values like keys or servers that are expected to be
replaced at launch time (example: AWS EC2 user-data).

The "reload_service" class is a notification dependency for many things,
so disabling it at each point is difficult and error-prone.  This commit
has "reload_service" ensure that the value of $service_ensure is not
'stopped', and only performs the reload if it's appropriate.

Otherwise, the method is a no-op.



Here's the relevant snippet of my output when running with server_ensure => 'stopped' before the patch.  This shows Packer's masterless Puppet provisioner failing to reload the Consul config, because it has placeholder syntax errors that user-data will fix on a real instance:

    amazon-ebs: Info: Class[Consul::Config]: Scheduling refresh of Class[Consul::Run_service]
    amazon-ebs: Info: Class[Consul::Run_service]: Scheduling refresh of Service[consul]
    amazon-ebs: Notice: /Stage[main]/Consul::Run_service/Service[consul]/enable: enable changed 'false' to 'true'
    amazon-ebs: Notice: /Stage[main]/Consul::Run_service/Service[consul]: Triggered 'refresh' from 1 events
    amazon-ebs: Info: Class[Consul::Reload_service]: Scheduling refresh of Exec[reload consul service]
    amazon-ebs: Notice: /Stage[main]/Consul::Reload_service/Exec[reload consul service]/returns: Error connecting to Consul agent: dial tcp 127.0.0.1:8400: connection refused
    amazon-ebs: Error: /Stage[main]/Consul::Reload_service/Exec[reload consul service]: Failed to call refresh: consul reload returned 1 instead of one of [0]
    amazon-ebs: Error: /Stage[main]/Consul::Reload_service/Exec[reload consul service]: consul reload returned 1 instead of one of [0]
    amazon-ebs: Info: Creating state file /var/lib/puppet/state/state.yaml
    amazon-ebs: Notice: Finished catalog run in 18.57 seconds
==> amazon-ebs: Terminating the source AWS instance...

Packer fails the build if any of the tools return an error, so the reload failure trickles up and aborts the AMI creation.

Here's a post-patch snippet.  "reload_service" is called, but becomes effectively a no-op.  The setup completes happily.



    amazon-ebs: Info: Class[Consul::Config]: Scheduling refresh of Class[Consul::Run_service]
    amazon-ebs: Info: Class[Consul::Run_service]: Scheduling refresh of Service[consul]
    amazon-ebs: Notice: /Stage[main]/Consul::Run_service/Service[consul]/enable: enable changed 'false' to 'true'
    amazon-ebs: Notice: /Stage[main]/Consul::Run_service/Service[consul]: Triggered 'refresh' from 1 events
    amazon-ebs: Info: Creating state file /var/lib/puppet/state/state.yaml
    amazon-ebs: Notice: Finished catalog run in 17.86 seconds
==> amazon-ebs: Stopping the source instance...

I realize this may be a bit of an odd case, and most people don't run with enable => true AND ensure => 'stopped', but it presents a real problem for our pre-built AMI workflow.

I'm totally open to discussing other ways to accomplish this as well.


