### PR TITLE
pretty config (that properly sorts)

### DIFF
--- a/lib/puppet/parser/functions/consul_sorted_json.rb
+++ b/lib/puppet/parser/functions/consul_sorted_json.rb
@@ -1,43 +1,161 @@
 require 'json'
 
-def sorted_json(obj)
-  case obj
-    when Fixnum, Float, TrueClass, FalseClass, NilClass
-      return obj.to_json
-    when String
-      # Convert quoted integers (string) to int
-      return (obj.match(/\A[-]?[0-9]+\z/) ? obj.to_i : obj).to_json
-    when Array
-      arrayRet = []
-      obj.each do |a|
-        arrayRet.push(sorted_json(a))
+module JSON
+  class << self
+    @@loop = 0
+
+    def sorted_generate(obj)
+      case obj
+        when Fixnum, Float, TrueClass, FalseClass, NilClass
+          return obj.to_json
+        when String
+          # Convert quoted integers (string) to int
+          return (obj.match(/\A[-]?[0-9]+\z/) ? obj.to_i : obj).to_json
+        when Array
+          arrayRet = []
+          obj.each do |a|
+            arrayRet.push(sorted_generate(a))
+          end
+          return "[" << arrayRet.join(',') << "]";
+        when Hash
+          ret = []
+          obj.keys.sort.each do |k|
+            ret.push(k.to_json << ":" << sorted_generate(obj[k]))
+          end
+          return "{" << ret.join(",") << "}";
+        else
+          raise Exception("Unable to handle object of type <%s>" % obj.class.to_s)
       end
-      return "[" << arrayRet.join(',') << "]";
-    when Hash
-      ret = []
-      obj.keys.sort.each do |k|
-        ret.push(k.to_json << ":" << sorted_json(obj[k]))
+    end
+
+    def sorted_pretty_generate(obj, indent_len=4)
+
+      # Indent length
+      indent = " " * indent_len
+
+      case obj
+
+        when Fixnum, Float, TrueClass, FalseClass, NilClass
+          return obj.to_json
+
+        when String
+          # Convert quoted integers (string) to int
+          return (obj.match(/\A[-]?[0-9]+\z/) ? obj.to_i : obj).to_json
+
+        when Array
+          arrayRet = []
+
+          # We need to increase the loop count before #each so the objects inside are indented twice.
+          # When we come out of #each we decrease the loop count so the closing brace lines up properly.
+          #
+          # If you start with @@loop = 1, the count will be as follows
+          #
+          # "start_join": [     <-- @@loop == 1
+          #   "192.168.50.20",  <-- @@loop == 2
+          #   "192.168.50.21",  <-- @@loop == 2
+          #   "192.168.50.22"   <-- @@loop == 2
+          # ] <-- closing brace <-- @@loop == 1
+          #
+          @@loop += 1
+          obj.each do |a|
+            arrayRet.push(sorted_pretty_generate(a, indent_len))
+          end
+          @@loop -= 1
+
+          return "[\n#{indent * (@@loop + 1)}" << arrayRet.join(",\n#{indent * (@@loop + 1)}") << "\n#{indent * @@loop}]";
+
+        when Hash
+          ret = []
+
+          # This loop works in a similar way to the above
+          @@loop += 1
+          obj.keys.sort.each do |k|
+            ret.push("#{indent * @@loop}" << k.to_json << ": " << sorted_pretty_generate(obj[k], indent_len))
+          end
+          @@loop -= 1
+
+          return "{\n" << ret.join(",\n") << "\n#{indent * @@loop}}";
+        else
+          raise Exception("Unable to handle object of type <%s>" % obj.class.to_s)
       end
-      return "{" << ret.join(",") << "}";
-    else
-      raise Exception("Unable to handle object of type <%s>" % obj.class.to_s)
-  end
-end
+
+    end # end def
+
+  end # end class
+
+end # end module
+
 
 module Puppet::Parser::Functions
   newfunction(:consul_sorted_json, :type => :rvalue, :doc => <<-EOS
-This function takes data, outputs making sure the hash keys are sorted
+This function takes unsorted hash and outputs JSON object making sure the keys are sorted.
+Optionally you can pass 2 additional parameters, pretty generate and indent length.
 
 *Examples:*
 
-    sorted_json({'key'=>'value'})
+    -------------------
+    -- UNSORTED HASH --
+    -------------------
+    unsorted_hash = {
+      'client_addr' => '127.0.0.1',
+      'bind_addr'   => '192.168.34.56',
+      'start_join'  => [
+        '192.168.34.60',
+        '192.168.34.61',
+        '192.168.34.62',
+      ],
+      'ports'       => {
+        'rpc'   => 8567,
+        'https' => 8500,
+        'http'  => -1,
+      },
+    }
 
-Would return: {'key':'value'}
+    -----------------
+    -- SORTED JSON --
+    -----------------
+
+    consul_sorted_json(unsorted_hash)
+
+    {"bind_addr":"192.168.34.56","client_addr":"127.0.0.1",
+    "ports":{"http":-1,"https":8500,"rpc":8567},
+    "start_join":["192.168.34.60","192.168.34.61","192.168.34.62"]}
+
+    ------------------------
+    -- PRETTY SORTED JSON --
+    ------------------------
+    Params: data <hash>, pretty <true|false>, indent <int>.
+
+    consul_sorted_json(unsorted_hash, true, 4)
+
+    {
+        "bind_addr": "192.168.34.56",
+        "client_addr": "127.0.0.1",
+        "ports": {
+            "http": -1,
+            "https": 8500,
+            "rpc": 8567
+        },
+        "start_join": [
+            "192.168.34.60",
+            "192.168.34.61",
+            "192.168.34.62"
+        ]
+    }
+
     EOS
-  ) do |arguments|
-    raise(Puppet::ParseError, "sorted_json(): Wrong number of arguments " +
-      "given (#{arguments.size} for 1)") if arguments.size != 1
-    json = arguments[0].delete_if {|key, value| value == :undef }
-    return sorted_json(json)
+  ) do |args|
+
+    unsorted_hash = args[0]      || {}
+    pretty        = args[1]      || false
+    indent_len    = args[2].to_i || 4
+
+    unsorted_hash.reject! {|key, value| value == :undef }
+
+    if pretty
+      return JSON.sorted_pretty_generate(unsorted_hash, indent_len) << "\n"
+    else
+      return JSON.sorted_generate(unsorted_hash)
+    end
   end
 end

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -75,6 +75,6 @@ define consul::check(
   File[$consul::config_dir] ->
   file { "${consul::config_dir}/check_${escaped_id}.json":
     ensure  => $ensure,
-    content => template('consul/check.json.erb'),
+    content => consul_sorted_json($check_hash, $consul::pretty_config, $consul::pretty_config_indent),
   } ~> Class['consul::reload_service']
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -92,7 +92,7 @@ class consul::config(
   file { 'consul config.json':
     ensure  => present,
     path    => "${consul::config_dir}/config.json",
-    content => consul_sorted_json($config_hash),
+    content => consul_sorted_json($config_hash, $consul::pretty_config, $consul::pretty_config_indent),
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,12 @@
 # [*config_hash*]
 #   Use this to populate the JSON config file for consul.
 #
+# [*pretty_config*]
+#   Generates a human readable JSON config file. Defaults to `false`.
+#
+# [*pretty_config_indent*]
+#   Toggle indentation for human readable JSON file. Defaults to `4`.
+#
 # [*install_method*]
 #   Valid strings: `package` - install via system package
 #                  `url`     - download and extract from a url. Defaults to `url`.
@@ -67,6 +73,8 @@ class consul (
   $extra_options         = '',
   $config_hash           = {},
   $config_defaults       = {},
+  $pretty_config         = false,
+  $pretty_config_indent  = 4,
   $service_enable        = true,
   $service_ensure        = 'running',
   $manage_service        = true,
@@ -88,6 +96,8 @@ class consul (
   validate_bool($restart_on_change)
   validate_hash($config_hash)
   validate_hash($config_defaults)
+  validate_bool($pretty_config)
+  validate_integer($pretty_config_indent)
   validate_hash($services)
   validate_hash($watches)
   validate_hash($checks)

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -60,7 +60,7 @@ define consul::service(
 
   file { "${consul::config_dir}/service_${id}.json":
     ensure  => $ensure,
-    content => consul_sorted_json($service_hash),
+    content => consul_sorted_json($service_hash, $consul::pretty_config, $consul::pretty_config_indent),
     require => File[$consul::config_dir],
   } ~> Class['consul::reload_service']
 }

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -136,6 +136,6 @@ define consul::watch(
   File[$consul::config_dir] ->
   file { "${consul::config_dir}/watch_${id}.json":
     ensure  => $ensure,
-    content => template('consul/watch.json.erb'),
+    content => consul_sorted_json($watch_hash, $consul::pretty_config, $consul::pretty_config_indent),
   } ~> Class['consul::reload_service']
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -252,6 +252,7 @@ describe 'consul' do
           'server' => false,
           'ports' => {
             'http' => 1,
+            'rpc'  => '8300',
           },
       },
       :config_hash => {
@@ -268,6 +269,26 @@ describe 'consul' do
     it { should contain_file('consul config.json').with_content(/"server":true/) }
     it { should contain_file('consul config.json').with_content(/"http":-1/) }
     it { should contain_file('consul config.json').with_content(/"https":8500/) }
+    it { should contain_file('consul config.json').with_content(/"rpc":8300/) }
+  end
+
+  context 'When pretty config is true' do
+    let(:params) {{
+      :pretty_config => true,
+      :config_hash => {
+          'bootstrap_expect' => '5',
+          'server' => true,
+          'ports' => {
+            'http'  => -1,
+            'https' => 8500,
+          },
+      }
+    }}
+    it { should contain_file('consul config.json').with_content(/"bootstrap_expect": 5,/) }
+    it { should contain_file('consul config.json').with_content(/"server": true/) }
+    it { should contain_file('consul config.json').with_content(/"http": -1,/) }
+    it { should contain_file('consul config.json').with_content(/"https": 8500/) }
+    it { should contain_file('consul config.json').with_content(/"ports": {/) }
   end
 
   context "When asked not to manage the user" do

--- a/spec/functions/consul_sorted_json_spec.rb
+++ b/spec/functions/consul_sorted_json_spec.rb
@@ -1,13 +1,44 @@
 require 'spec_helper'
 
-describe 'consul_sorted_json' do
-  it { should run.with_params({'foo' => :undef}).and_return("{}") }
-  it { should run.with_params({'b' => 1, 'a' => 2, 'c' => 3}).and_return('{"a":2,"b":1,"c":3}')}
-  it { should run.with_params({
-    'w' => -1,
-    'x' => '8500',
-    'y' => '-8656',
-    'z' => 'foo bar 123 4 5 6',
-    }).and_return('{"w":-1,"x":8500,"y":-8656,"z":"foo bar 123 4 5 6"}')
-  }
+describe 'consul_sorted_json', :type => :puppet_function do
+
+  let(:test_hash){ { 'z' => 3, 'a' => '1', 'p' => '2', 's' => '-7' } }
+  before do
+    @json = subject.call([test_hash, true])
+  end
+  it "sorts keys" do
+    expect( @json.index('a') ).to be < @json.index('p')
+    expect( @json.index('p') ).to be < @json.index('s')
+    expect( @json.index('s') ).to be < @json.index('z')
+  end
+
+  it "prints pretty json" do
+    expect(@json.split("\n").size).to eql(test_hash.size + 2) # +2 for { and }
+  end
+
+  it "prints ugly json" do
+    json = subject.call([test_hash]) # pretty=false by default
+    expect(json.split("\n").size).to eql(1)
+  end
+
+  it "validate ugly json" do
+    json = subject.call([test_hash]) # pretty=false by default
+    expect(json).to match("{\"a\":1,\"p\":2,\"s\":-7,\"z\":3}")
+  end
+
+  context 'nesting' do
+
+    let(:nested_test_hash){ { 'z' => [{'l' => 3, 'k' => '2', 'j'=> '1'}],
+                              'a' => {'z' => '3', 'x' => '1', 'y' => '2'},
+                              'p' => [ '9','8','7'] } }
+    before do
+      @json = subject.call([nested_test_hash, true])
+    end
+
+    it "sorts nested hashes" do
+      expect( @json.index('x') ).to be < @json.index('y')
+      expect( @json.index('y') ).to be < @json.index('z')
+    end
+
+  end
 end

--- a/templates/check.json.erb
+++ b/templates/check.json.erb
@@ -1,2 +1,0 @@
-<%- require 'json' -%>
-<%= JSON.pretty_generate(Hash[@check_hash.sort]) %>

--- a/templates/watch.json.erb
+++ b/templates/watch.json.erb
@@ -1,2 +1,0 @@
-<%- require 'json' -%>
-<%= JSON.pretty_generate(Hash[@watch_hash.sort]) %>


### PR DESCRIPTION
Generate pretty consul config, initially suggested by @teaforthecat.

* Can be toggled via `pretty_config` param, defaults to `false`.
* Indentation length can also be toggled.
* Updated config.pp and services.pp to use pretty generate.
* Updated checks.pp and watches.pp to use `consul_sorted_json()`.
* Updated docs on how to use `consul_sorted_json()`.

:exclamation: view it [without whitespace](https://github.com/solarkennedy/puppet-consul/pull/175/files?w=1)