### PR TITLE
Rework sysv stop script to fix issues

### DIFF
--- a/templates/consul.sysv.erb
+++ b/templates/consul.sysv.erb
@@ -96,7 +96,7 @@ stop() {
         killproc $KILLPROC_OPT $CONSUL
         retcode=$?
 
-        rm -f /var/lock/subsys/consul
+        rm -f /var/lock/subsys/consul $PID_FILE
         return $retcode
 }
 

--- a/templates/consul.sysv.erb
+++ b/templates/consul.sysv.erb
@@ -61,18 +61,42 @@ start() {
 }
 
 stop() {
+        DELAY=5 # seconds maximum to wait for a leave
+
         echo -n "Shutting down consul: "
+        mkpidfile
+
         # If consul is not acting as a server, exit gracefully
+        # Use SIGINT to create a "leave" event, unless the user has explicitly
+        # changed that behavior in the Consul config.
         if ("${CONSUL}" info ${RPC_ADDR} 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
-            "$CONSUL" leave ${RPC_ADDR}
+            consul_pid=$(cat $PID_FILE)
+            killproc $KILLPROC_OPT $CONSUL -INT
+            retcode=$?
+
+            # We'll wait if necessary to make sure the leave works, and return
+            # early if we can.  If not, escalate to harsher signals.
+            try=0
+            while [ $try -lt $DELAY ]; do
+                if ! checkpid $consul_pid ; then
+                    rm -f /var/lock/subsys/consul
+                    return $retcode
+                fi
+                sleep 1
+                let try+=1
+            done
         fi
 
-        # If acting as a server, or if leave failed, kill it.
-        mkpidfile
-        killproc $KILLPROC_OPT $CONSUL -9
-
+        # If acting as a server, use a SIGTERM to avoid a leave.
+        # This behavior is also configurable.  Avoid doing a "leave" because
+        # having servers missing is a bad thing that we want to notice.
+        #
+        # A SIGTERM will mark the node as "failed" until it rejoins.
+        # killproc with no arguments uses TERM, then escalates to KILL.
+        killproc $KILLPROC_OPT $CONSUL
         retcode=$?
-        rm -f /var/lock/subsys/consul $PID_FILE
+
+        rm -f /var/lock/subsys/consul
         return $retcode
 }
 
@@ -102,4 +126,7 @@ case "$1" in
         exit 1
         ;;
 esac
-exit $?
+retcode=$?
+# Don't let the [OK] get stomped on.
+echo
+exit $retcode


### PR DESCRIPTION
Addresses #174.

I commented the stop function extensively so the next person in there will understand what I was trying to do and the signal logic there.  It's pretty similar to what it was doing before, but without the race condition and using more appropriate signals.

In my tests the SIGINT-triggered leave happens in less than 1 second, but takes enough time that a wait check is necessary to avoid the race.  We wait up to 5 seconds, checking every second to see if it's finished.

Commit message follows.

--
The sysv stop script had been set to issue a SIGKILL (-9) to ensure that
a server would not perform a leave operation.  That's excessive, and the
logic in that section had a race condition that could result in a client
unpredictably ending in either a "left" or "failed" state.

Reworked this section to issue a SIGINT to clients (which initiates a
leave by default) and then check for success.  If the leave operation
fails or if the agent is acting as a server, then the standard killproc
is issued, which tries a SIGTERM, followed by a SIGKILL if the TERM is
not effective.

Also fixed a minor issue where the stop return status would often be
displayed in the prompt line.  The start status is eaten by Consul's
default stdout logging, so there's no fixing that.  It simply ends up in
the log file.

