### PR TITLE
consul init sysv: lower stop priority

### DIFF
--- a/templates/consul.sysv.erb
+++ b/templates/consul.sysv.erb
@@ -4,7 +4,7 @@
 #
 #       Daemonize the consul agent.
 #
-# chkconfig:   2345 95 95
+# chkconfig:   2345 95 20
 # description: Service discovery and configuration made easy. \
 #  Distributed, highly available, and datacenter-aware.
 # processname: consul


### PR DESCRIPTION
Lower the stop priority in order to make sure that a consul agent is
able to leave the cluster gracefully when shut down.