### PR TITLE
Remove management of unzip package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,9 +15,6 @@ class consul::install {
 
   case $consul::install_method {
     'url': {
-      if $::operatingsystem != 'darwin' {
-        ensure_packages(['unzip'], { 'before' => Staging::File['consul.zip'] })
-      }
       staging::file { 'consul.zip':
         source => $consul::real_download_url
       } ->
@@ -32,9 +29,6 @@ class consul::install {
       }
 
       if ($consul::ui_dir and $consul::data_dir) {
-        if $::operatingsystem != 'darwin' {
-          Package['unzip'] -> Staging::Deploy['consul_web_ui.zip']
-        }
         file { "${consul::data_dir}/${consul::version}_web_ui":
           ensure => 'directory',
           owner  => 'root',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -67,25 +67,6 @@ describe 'consul' do
     it { should_not contain_exec('join consul wan') }
   end
 
-  context 'Require unzip package when installing via URL' do
-    it { should contain_staging__file('consul.zip').that_requires('Package[unzip]') }
-  end
-
-  context "Require unzip package when installing UI via URL" do
-    let(:params) {{
-      :config_hash => {
-        'data_dir' => '/dir1',
-        'ui_dir'   => '/dir1/dir2',
-      },
-    }}
-    it { should contain_staging__deploy('consul_web_ui.zip').that_requires('Package[unzip]') }
-  end
-
-  context 'OS X should not contain unzip package' do
-    let(:facts) {{ :operatingsystem => 'darwin' }}
-    it { should_not contain_package('unzip') }
-  end
-
   context 'When requesting to install via a package with defaults' do
     let(:params) {{
       :install_method => 'package'


### PR DESCRIPTION
The unzip package is already managed by most people's puppet infrastructure, so installing it here introduces resource conflicts.

Even with the ensure_resource function, there are parse-order dependent conflicts if you have the same packages declared elsewhere.

I made this change because I get a resource conflict without it. I'd be open to another approach but wanted to contribute the change back upstream in case other people were running into the same problem.