### PR TITLE
Add parameter for setting port to custom acl type

### DIFF
--- a/lib/puppet/provider/consul_acl/default.rb
+++ b/lib/puppet/provider/consul_acl/default.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:consul_acl).provide(
 
     # this might be configurable by searching /etc/consul.d
     # but would break for anyone using nonstandard paths
-    uri = URI('http://localhost:8500/v1/acl')
+    uri = URI("http://localhost:#{:port}/v1/acl")
     http = Net::HTTP.new(uri.host, uri.port)
 
     path=uri.request_uri + "/list?token=#{acl_api_token}"
@@ -47,7 +47,7 @@ Puppet::Type.type(:consul_acl).provide(
   end
 
   def put_acl(method,body)
-    uri = URI('http://localhost:8500/v1/acl')
+    uri = URI("http://localhost:#{:port}/v1/acl")
     http = Net::HTTP.new(uri.host, uri.port)
     acl_api_token = @resource[:acl_api_token]
     path = uri.request_uri + "/#{method}?token=#{acl_api_token}"

--- a/lib/puppet/type/consul_acl.rb
+++ b/lib/puppet/type/consul_acl.rb
@@ -41,6 +41,14 @@ Puppet::Type.newtype(:consul_acl) do
     end
   end
 
+  newproperty(:port) do
+    desc 'consul port'
+    value = 8500 if value.nil?
+    validate do |value|
+      raise ArgumentError, "The port number must be a number" if not value.is_a?(Integer)
+    end
+  end
+
   autorequire(:service) do
     ['consul']
   end


### PR DESCRIPTION
@solarkennedy,

I need to set the port for consul, but it's hard coded into the type provider. Added a parameter to the type and set the default to 8500.

Thanks