### PR TITLE
Updating staging file download to use the version and symlink

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,17 +15,24 @@ class consul::install {
 
   case $consul::install_method {
     'url': {
-      staging::file { 'consul.zip':
-        source => $consul::real_download_url
+      staging::file { "consul-${consul::version}.${consul::download_extension}":
+        source => $consul::real_download_url,
       } ->
-      staging::extract { 'consul.zip':
-        target  => $consul::bin_dir,
-        creates => "${consul::bin_dir}/consul",
+      file { "${::staging::path}/consul-${consul::version}":
+        ensure => directory,
       } ->
-      file { "${consul::bin_dir}/consul":
-        owner => 'root',
-        group => 0, # 0 instead of root because OS X uses "wheel".
-        mode  => '0555',
+      staging::extract { "consul-${consul::version}.${consul::download_extension}":
+        target  => "${::staging::path}/consul-${consul::version}",
+        creates => "${::staging::path}/consul-${consul::version}/consul",
+      } ->
+      file {
+        "${::staging::path}/consul-${consul::version}/consul":
+          owner => 'root',
+          group => 0, # 0 instead of root because OS X uses "wheel".
+          mode  => '0555';
+        "${consul::bin_dir}/consul":
+          ensure => link,
+          target => "${::staging::path}/consul-${consul::version}/consul";
       }
 
       if ($consul::ui_dir and $consul::data_dir) {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -32,6 +32,7 @@ class consul::install {
           mode  => '0555';
         "${consul::bin_dir}/consul":
           ensure => link,
+          notify => $consul::notify_service,
           target => "${::staging::path}/consul-${consul::version}/consul";
       }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,6 +15,7 @@ class consul::install {
 
   case $consul::install_method {
     'url': {
+      include staging
       staging::file { "consul-${consul::version}.${consul::download_extension}":
         source => $consul::real_download_url,
       } ->

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -85,6 +85,8 @@ describe 'consul' do
 
   context "When installing via URL by default" do
     it { should contain_staging__file('consul-0.5.2.zip').with(:source => 'https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip') }
+    it { should contain_file('/usr/local/bin/consul').that_notifies('Class[consul::run_service]') }
+    #it { should contain_notify(['Class[consul::run_service]']) }
   end
 
   context "When installing via URL by with a special version" do
@@ -92,6 +94,7 @@ describe 'consul' do
       :version   => '42',
     }}
     it { should contain_staging__file('consul-42.zip').with(:source => 'https://releases.hashicorp.com/consul/42/consul_42_linux_amd64.zip') }
+    it { should contain_file('/usr/local/bin/consul').that_notifies('Class[consul::run_service]') }
   end
 
   context "When installing via URL by with a custom url" do
@@ -99,6 +102,7 @@ describe 'consul' do
       :download_url   => 'http://myurl',
     }}
     it { should contain_staging__file('consul-0.5.2.zip').with(:source => 'http://myurl') }
+    it { should contain_file('/usr/local/bin/consul').that_notifies('Class[consul::run_service]') }
   end
 
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -84,21 +84,21 @@ describe 'consul' do
   end
 
   context "When installing via URL by default" do
-    it { should contain_staging__file('consul.zip').with(:source => 'https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip') }
+    it { should contain_staging__file('consul-0.5.2.zip').with(:source => 'https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip') }
   end
 
   context "When installing via URL by with a special version" do
     let(:params) {{
       :version   => '42',
     }}
-    it { should contain_staging__file('consul.zip').with(:source => 'https://releases.hashicorp.com/consul/42/consul_42_linux_amd64.zip') }
+    it { should contain_staging__file('consul-42.zip').with(:source => 'https://releases.hashicorp.com/consul/42/consul_42_linux_amd64.zip') }
   end
 
   context "When installing via URL by with a custom url" do
     let(:params) {{
       :download_url   => 'http://myurl',
     }}
-    it { should contain_staging__file('consul.zip').with(:source => 'http://myurl') }
+    it { should contain_staging__file('consul-0.5.2.zip').with(:source => 'http://myurl') }
   end
 
 


### PR DESCRIPTION
This is the same approach used by consul-template to allow for the version of consul to be upgraded/downgraded accordingly by downloading the artifact zip to a versioned folder and just symlinking the binary to the appropriate one.

This is also similar to how homebrew on Mac works as well.

I'm sure there are a few pieces missing, like service restart and such is probably desired to have on there as well, just didn't want to dive too deep if we didn't think this is a viable solution.