### PR TITLE
mitigate .to_json segfaults on Ruby 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install: rm Gemfile.lock || true
 sudo: false
 cache: bundler
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
@@ -13,6 +14,8 @@ env:
   - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.7.4" FUTURE_PARSER=yes STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.8.4"
+  - PUPPET_VERSION="~> 3.8.4" FUTURE_PARSER=yes STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 4.0.0"
   - PUPPET_VERSION="~> 4.1.0"
 matrix:
@@ -35,8 +38,12 @@ matrix:
     env: PUPPET_VERSION="~> 3.4.0"
   - rvm: 1.9.3
     env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
   - rvm: 1.9.3
     env: PUPPET_VERSION="~> 4.1.0"
   - rvm: 2.0.0

--- a/lib/puppet/parser/functions/consul_sorted_json.rb
+++ b/lib/puppet/parser/functions/consul_sorted_json.rb
@@ -6,11 +6,8 @@ module JSON
 
     def sorted_generate(obj)
       case obj
-        when Fixnum, Float, TrueClass, FalseClass, NilClass
-          return obj.to_json
-        when String
-          # Convert quoted integers (string) to int
-          return (obj.match(/\A[-]?[0-9]+\z/) ? obj.to_i : obj).to_json
+        when NilClass,Fixnum, Float, TrueClass, FalseClass,String
+          return simple_generate(obj)
         when Array
           arrayRet = []
           obj.each do |a|
@@ -34,14 +31,8 @@ module JSON
       indent = " " * indent_len
 
       case obj
-
-        when Fixnum, Float, TrueClass, FalseClass, NilClass
-          return obj.to_json
-
-        when String
-          # Convert quoted integers (string) to int
-          return (obj.match(/\A[-]?[0-9]+\z/) ? obj.to_i : obj).to_json
-
+        when NilClass,Fixnum, Float, TrueClass, FalseClass,String
+          return simple_generate(obj)
         when Array
           arrayRet = []
 
@@ -80,6 +71,20 @@ module JSON
       end
 
     end # end def
+    private
+    # simplify jsonification of standard types
+    def simple_generate(obj)
+      case obj
+        when NilClass
+          'null'
+        when Fixnum, Float, TrueClass, FalseClass
+          "#{obj}"
+        else
+          # Should be a string
+          # keep string integers unquoted
+          (obj =~ /\A[-]?\d+\z/) ? obj : obj.to_json
+      end
+    end
 
   end # end class
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -297,7 +297,7 @@ describe 'consul' do
     it { should contain_file('consul config.json').with_content(/"server": true/) }
     it { should contain_file('consul config.json').with_content(/"http": -1,/) }
     it { should contain_file('consul config.json').with_content(/"https": 8500/) }
-    it { should contain_file('consul config.json').with_content(/"ports": {/) }
+    it { should contain_file('consul config.json').with_content(/"ports": \{/) }
   end
 
   context "When asked not to manage the user" do
@@ -360,7 +360,7 @@ describe 'consul' do
     it { should contain_file('consul config.json').with(
       :owner => 'custom_consul_user',
       :group => 'custom_consul_group',
-      :mode  => '0600',
+      :mode  => '0600'
     )}
   end
 

--- a/spec/functions/consul_sorted_json_spec.rb
+++ b/spec/functions/consul_sorted_json_spec.rb
@@ -1,5 +1,37 @@
 require 'spec_helper'
 
+RSpec.shared_examples 'handling_simple_types' do |pretty|
+  it 'handles nil' do
+    expect(subject.call([ {'key' => nil }],pretty)).to eql('{"key":null}')
+  end
+  it 'handles true' do
+    expect(subject.call([{'key' => true }],pretty)).to eql('{"key":true}')
+  end
+  it 'handles nil' do
+    expect(subject.call([{'key' => false }],pretty)).to eql('{"key":false}')
+  end
+  it 'handles positive integer' do
+    expect(subject.call([{'key' => 1 }],pretty)).to eql('{"key":1}')
+  end
+  it 'handles negative integer' do
+    expect(subject.call([{'key' => -1 }],pretty)).to eql('{"key":-1}')
+  end
+  it 'handles positive float' do
+    expect(subject.call([{'key' => 1.1 }],pretty)).to eql('{"key":1.1}')
+  end
+  it 'handles negative float' do
+    expect(subject.call([{'key' => -1.1 }],pretty)).to eql('{"key":-1.1}')
+  end
+  it 'handles integer in a string' do
+    expect(subject.call([{'key' => '1' }],pretty)).to eql('{"key":1}')
+  end
+  it 'handles negative integer in a string' do
+    expect(subject.call([{'key' => '-1' }],pretty)).to eql('{"key":-1}')
+  end
+  it 'handles simple string' do
+    expect(subject.call([{'key' => 'aString' }],pretty)).to eql("{\"key\":\"aString\"}")
+  end
+end
 describe 'consul_sorted_json', :type => :puppet_function do
 
   let(:test_hash){ { 'z' => 3, 'a' => '1', 'p' => '2', 's' => '-7' } }
@@ -40,5 +72,13 @@ describe 'consul_sorted_json', :type => :puppet_function do
       expect( @json.index('y') ).to be < @json.index('z')
     end
 
+  end
+  context 'test simple behavior' do
+    context 'sorted' do
+      include_examples 'handling_simple_types', false
+    end
+    context 'sorted pretty' do
+      include_examples 'handling_simple_types', true
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ end
 RSpec.configure do |c|
   c.mock_framework = :rspec
   c.before(:each) do
-    Puppet::Indirector::Hiera.stub(:hiera => hiera_stub)
+    allow(Puppet::Indirector::Hiera).to receive(:hiera) { hiera_stub }
   end
 
 end


### PR DESCRIPTION
Regularly we had processes on our puppetmaster - (still) running on
Ruby 1.8.7 - segfaulting on line 13 of consul_sorted_json.rb and we
then even had ghost processes (not tracked by passenger anymore)
consuming 100% of memory doing nothing when attaching with strace.

This might be a problem of either Ruby 1.8.7 itself (similar to
https://groups.google.com/forum/#!msg/puppet-users/ag1rAF7o_Uw/1hjtABrmzwgJ)
or the used C json library. Looking at what we are doing on line 13,
we figured out, that we could reduce the calls to .to_json and
hence might be able to mitigate the segfaults.

Only changing line 13 helped, but moved the segfaults to line 10,
looking at that line, we figured out, that we can avoid even
further .to_json calls.

Running this patch on 2 puppet masters for 8 hours didn't show any
segfaults, nor any high running cpu processes, which usually started
to appear quite quickly.