### PR TITLE
Add support for tcp check type

### DIFF
--- a/lib/puppet/parser/functions/consul_validate_checks.rb
+++ b/lib/puppet/parser/functions/consul_validate_checks.rb
@@ -15,14 +15,18 @@ def validate_checks(obj)
           end
         elsif obj.key?("http")
           if (! obj.key?("interval"))
-            raise Puppet::ParseError.new('http must be defined for interval checks')
+            raise Puppet::ParseError.new('interval must be defined for http checks')
+          end
+        elsif obj.key?("tcp")
+          if (! obj.key?("interval"))
+            raise Puppet::ParseError.new('interval must be defined for tcp checks')
           end
         elsif obj.key?("script")
           if (! obj.key?("interval"))
-            raise Puppet::ParseError.new('script must be defined for interval checks')
+            raise Puppet::ParseError.new('interval must be defined for script checks')
           end
         else
-          raise Puppet::ParseError.new('One of ttl, script, or http must be defined.')
+          raise Puppet::ParseError.new('One of http, script, tcp, or ttl must be defined.')
         end
     else
       raise Puppet::ParseError.new("Unable to handle object of type <%s>" % obj.class.to_s)

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -23,6 +23,10 @@
 #   Full path to the location of the healthcheck script. Must be nagios
 #   compliant with regards to the return codes.
 #
+# [*tcp*]
+#   The IP/hostname and port for the service healthcheck. Should be in
+#   'hostname:port' format.
+#
 # [*interval*]
 #   Value in seconds for the interval between runs of the check
 #
@@ -44,6 +48,7 @@ define consul::check(
   $ttl        = undef,
   $http       = undef,
   $script     = undef,
+  $tcp        = undef,
   $interval   = undef,
   $service_id = undef,
   $timeout    = undef,
@@ -58,6 +63,7 @@ define consul::check(
     'ttl'        => $ttl,
     'http'       => $http,
     'script'     => $script,
+    'tcp'        => $tcp,
     'interval'   => $interval,
     'timeout '   => $timeout,
     'service_id' => $service_id,

--- a/spec/defines/consul_check_spec.rb
+++ b/spec/defines/consul_check_spec.rb
@@ -156,6 +156,52 @@ describe 'consul::check' do
         .that_notifies("Class[consul::reload_service]") \
     }
   end
+  describe 'with tcp' do
+    let(:params) {{
+      'tcp'      => 'localhost:80',
+      'interval' => '30s',
+    }}
+    it {
+      should contain_file("/etc/consul/check_my_check.json") \
+        .with_content(/"id" *: *"my_check"/) \
+        .with_content(/"name" *: *"my_check"/) \
+        .with_content(/"check" *: *\{/) \
+        .with_content(/"tcp" *: *"localhost:80"/) \
+        .with_content(/"interval" *: *"30s"/)
+    }
+  end
+  describe 'with script and service_id' do
+    let(:params) {{
+      'tcp'        => 'localhost:80',
+      'interval'   => '30s',
+      'service_id' => 'my_service'
+    }}
+    it {
+      should contain_file("/etc/consul/check_my_check.json") \
+        .with_content(/"id" *: *"my_check"/) \
+        .with_content(/"name" *: *"my_check"/) \
+        .with_content(/"check" *: *\{/) \
+        .with_content(/"tcp" *: *"localhost:80"/) \
+        .with_content(/"interval" *: *"30s"/) \
+        .with_content(/"service_id" *: *"my_service"/)
+    }
+  end
+  describe 'reload service with script and token' do
+    let(:params) {{
+      'tcp'      => 'localhost:80',
+      'interval' => '30s',
+      'token'    => 'too-cool-for-this-script'
+    }}
+    it {
+      should contain_file("/etc/consul/check_my_check.json") \
+        .with_content(/"id" *: *"my_check"/) \
+        .with_content(/"name" *: *"my_check"/) \
+        .with_content(/"tcp" *: *"localhost:80"/) \
+        .with_content(/"interval" *: *"30s"/) \
+        .with_content(/"token" *: *"too-cool-for-this-script"/) \
+        .that_notifies("Class[consul::reload_service]") \
+    }
+  end
   describe 'with both ttl and interval' do
     let(:params) {{
       'ttl' => '30s',
@@ -197,7 +243,7 @@ describe 'consul::check' do
       'script' => 'true',
     }}
     it {
-      should raise_error(Puppet::Error, /script must be defined for interval checks/)
+      should raise_error(Puppet::Error, /interval must be defined for script checks/)
     }
   end
   describe 'with http but no interval' do
@@ -205,7 +251,15 @@ describe 'consul::check' do
       'http' => 'http://localhost/health',
     }}
     it {
-      should raise_error(Puppet::Error, /http must be defined for interval checks/)
+      should raise_error(Puppet::Error, /interval must be defined for http checks/)
+    }
+  end
+  describe 'with tcp but no interval' do
+    let(:params) {{
+      'tcp' => 'localhost:80',
+    }}
+    it {
+      should raise_error(Puppet::Error, /interval must be defined for tcp checks/)
     }
   end
   describe 'with a / in the id' do

--- a/spec/functions/consul_validate_checks_spec.rb
+++ b/spec/functions/consul_validate_checks_spec.rb
@@ -53,4 +53,22 @@ describe 'consul_validate_checks' do
       }
     ]).and_raise_error(Exception) }
   end
+
+  describe 'validate tcp check' do
+    it {should run.with_params([
+      {
+        'tcp'      => 'localhost:80',
+        'interval' => '30s',
+      }
+    ])}
+  end
+
+  describe 'validate tcp missing interval' do
+    it {should run.with_params([
+      {
+        'tcp' => 'localhost:80'
+      }
+    ]).and_raise_error(Exception) }
+  end
+
 end


### PR DESCRIPTION
These change build on @tzz's patch in #204, and adds full support for the `tcp` check type. I've updated both the `check.pp` manifest and the `consul_validate_checks()` parser function to properly support the type, as well as added tests that emulate the testing done for the other check types. If you need any changes made, or I missed something, let me know and I can update the branch.