### PR TITLE
Fix web_ui installation on Consul 0.6.0 and greater

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,6 @@
-# == Class consul::intall
+# == Class consul::install
 #
-# Installs consule based in the parameters from init
+# Installs consul based on the parameters from init
 #
 class consul::install {
 
@@ -38,20 +38,30 @@ class consul::install {
       }
 
       if ($consul::ui_dir and $consul::data_dir) {
+
+        # The 'dist' dir was removed from the web_ui archive in Consul version 0.6.0
+        if (versioncmp($::consul::version, '0.6.0') < 0) {
+          $staging_creates = "${consul::data_dir}/${consul::version}_web_ui/dist"
+          $ui_symlink_target = $staging_creates
+        } else {
+          $staging_creates = "${consul::data_dir}/${consul::version}_web_ui/index.html"
+          $ui_symlink_target = "${consul::data_dir}/${consul::version}_web_ui"
+        }
+
         file { "${consul::data_dir}/${consul::version}_web_ui":
           ensure => 'directory',
           owner  => 'root',
           group  => 0, # 0 instead of root because OS X uses "wheel".
           mode   => '0755',
         } ->
-        staging::deploy { 'consul_web_ui.zip':
+        staging::deploy { "consul_web_ui-${consul::version}.zip":
           source  => $consul::real_ui_download_url,
           target  => "${consul::data_dir}/${consul::version}_web_ui",
-          creates => "${consul::data_dir}/${consul::version}_web_ui/dist",
+          creates => $staging_creates,
         } ->
         file { $consul::ui_dir:
           ensure => 'symlink',
-          target => "${consul::data_dir}/${consul::version}_web_ui/dist",
+          target => $ui_symlink_target,
         }
       }
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -133,7 +133,7 @@ describe 'consul' do
     it { should_not contain_package('consul') }
     it { should_not contain_package('consul_ui') }
     it { should_not contain_staging__file('consul.zip') }
-    it { should_not contain_staging__file('consul_web_ui.zip') }
+    it { should_not contain_staging__file('consul_web_ui-0.5.2.zip') }
   end
 
   context "When installing UI via URL by default" do
@@ -143,20 +143,44 @@ describe 'consul' do
         'ui_dir'   => '/dir1/dir2',
       },
     }}
-    it { should contain_staging__file('consul_web_ui.zip').with(:source => 'https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_web_ui.zip') }
-    it { should contain_file('/dir1/dir2').that_requires('Staging::Deploy[consul_web_ui.zip]') }
+    it { should contain_staging__deploy('consul_web_ui-0.5.2.zip').with(:source => 'https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_web_ui.zip') }
+    it { should contain_file('/dir1/dir2').that_requires('Staging::Deploy[consul_web_ui-0.5.2.zip]') }
     it { should contain_file('/dir1/dir2').with(:ensure => 'symlink') }
   end
 
-  context "When installing UI via URL by with a special version" do
+  context "When installing UI via URL with a special version" do
     let(:params) {{
-      :version => '42',
+      :version     => '42',
       :config_hash => {
         'data_dir' => '/dir1',
         'ui_dir'   => '/dir1/dir2',
       },
     }}
-    it { should contain_staging__file('consul_web_ui.zip').with(:source => 'https://releases.hashicorp.com/consul/42/consul_42_web_ui.zip') }
+    it { should contain_staging__deploy('consul_web_ui-42.zip').with(:source => 'https://releases.hashicorp.com/consul/42/consul_42_web_ui.zip') }
+  end
+
+  context "When installing UI via URL when version < 0.6.0" do
+    let(:params) {{
+      'version'    => '0.5.99',
+      :config_hash => {
+        'data_dir' => '/dir1',
+        'ui_dir'   => '/dir1/dir2',
+      },
+    }}
+    it { should contain_staging__deploy('consul_web_ui-0.5.99.zip').with(:creates => %r{/dist$}) }
+    it { should contain_file('/dir1/dir2').with(:target => %r{/dist$}) }
+  end
+
+  context "When installing UI via URL when version >= 0.6.0" do
+    let(:params) {{
+      'version'    => '0.6.0',
+      :config_hash => {
+        'data_dir' => '/dir1',
+        'ui_dir'   => '/dir1/dir2',
+      },
+    }}
+    it { should contain_staging__deploy('consul_web_ui-0.6.0.zip').with(:creates => %r{/index\.html$}) }
+    it { should contain_file('/dir1/dir2').with(:target => %r{_web_ui$}) }
   end
 
   context "When installing UI via URL by with a custom url" do
@@ -167,7 +191,7 @@ describe 'consul' do
         'ui_dir'   => '/dir1/dir2',
       },
     }}
-    it { should contain_staging__deploy('consul_web_ui.zip').with(:source => 'http://myurl') }
+    it { should contain_staging__deploy('consul_web_ui-0.5.2.zip').with(:source => 'http://myurl') }
   end
 
   context "By default, a user and group should be installed" do


### PR DESCRIPTION
The web_ui distribution file in Consul 0.6.0 no longer has a `dist/` directory as part of the archive's path. This change adds support web_ui archives for versions >= 0.6.0 as well as maintain compatibility with the older releases. It also fixes a specific issue where the generic `consul_web_ui.zip` file name would block upgrades to newer versions.  I've also updated existing tests, and written new tests for the version check.

If you think the version check in install.pp could be clearer, or if there is anything else you would prefer to be done differently, let me know and I'll be glad to update it.