### PR TITLE
Add support of OpenSuSE and SLED

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,8 +55,14 @@ class consul::params {
     }
   } elsif $::operatingsystem == 'Archlinux' {
     $init_style = 'systemd'
-  } elsif $::operatingsystem == 'SLES' {
-    $init_style = 'sles'
+  } elsif $::operatingsystem == 'OpenSuSE' {
+    $init_style = 'systemd'
+  } elsif $::operatingsystem =~ /SLE[SD]/ {
+    if versioncmp($::operatingsystemrelease, '12.0') < 0 {
+      $init_style = 'sles'
+    } else {
+      $init_style = 'systemd'
+    }
   } elsif $::operatingsystem == 'Darwin' {
     $init_style = 'launchd'
   } elsif $::operatingsystem == 'Amazon' {

--- a/metadata.json
+++ b/metadata.json
@@ -77,6 +77,27 @@
         "20",
         "21"
       ]
+    },
+    {
+      "operatingsystem": "OpenSuSE",
+      "operatingsystemrelease": [
+        "13.1",
+        "13.2"
+      ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "11.4",
+        "12.0"
+      ]
+    },
+    {
+      "operatingsystem": "SLED",
+      "operatingsystemrelease": [
+        "11.4",
+        "12.0"
+      ]
     }
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -690,6 +690,33 @@ describe 'consul' do
     it { should contain_class('consul').with_init_style('debian') }
   end
 
+  context "On opensuse" do
+    let(:facts) {{
+      :operatingsystem => 'OpenSuSE',
+      :operatingsystemrelease => '13.1'
+    }}
+
+    it { should contain_class('consul').with_init_style('systemd') }
+  end
+
+  context "On SLED" do
+    let(:facts) {{
+      :operatingsystem => 'SLED',
+      :operatingsystemrelease => '11.4'
+    }}
+
+    it { should contain_class('consul').with_init_style('sles') }
+  end
+
+  context "On SLES" do
+    let(:facts) {{
+      :operatingsystem => 'SLES',
+      :operatingsystemrelease => '12.0'
+    }}
+
+    it { should contain_class('consul').with_init_style('systemd') }
+  end
+
   # Config Stuff
   context "With extra_options" do
     let(:params) {{


### PR DESCRIPTION
All currently supported versions of OpenSuSE use systemd. Suse
Enterprise Linux has two flavors: Server and Desktop. The 11.x release
still uses sysv but the 12.0 release uses systemd.

Signed-off-by: Konrad Scherer <Konrad.Scherer@windriver.com>