### PR TITLE
ACL fixes - idempotentcy and port bug.

### DIFF
--- a/lib/puppet/provider/consul_acl/default.rb
+++ b/lib/puppet/provider/consul_acl/default.rb
@@ -6,14 +6,35 @@ Puppet::Type.type(:consul_acl).provide(
 ) do
   mk_resource_methods
 
-  def self.list_resources(acl_api_token)
+  def self.prefetch(resources)
+    resources.each do |name, resource|
+      Puppet.debug("prefetching for #{name}")
+      port = resource[:port]
+      token = resource[:acl_api_token]
+
+      found_acls = list_resources(token, port).select do |acl|
+        acl[:name] == name
+      end
+
+      found_acl = found_acls.first || nil
+      if found_acl
+        Puppet.debug("found #{found_acl}")
+        resource.provider = new(found_acl)
+      else
+        Puppet.debug("found none #{name}")
+        resource.provider = new({:ensure => :absent})
+      end
+    end
+  end
+
+  def self.list_resources(acl_api_token, port)
     if @acls
       return @acls
     end
 
     # this might be configurable by searching /etc/consul.d
     # but would break for anyone using nonstandard paths
-    uri = URI("http://localhost:#{:port}/v1/acl")
+    uri = URI("http://localhost:#{port}/v1/acl")
     http = Net::HTTP.new(uri.host, uri.port)
 
     path=uri.request_uri + "/list?token=#{acl_api_token}"
@@ -47,7 +68,7 @@ Puppet::Type.type(:consul_acl).provide(
   end
 
   def put_acl(method,body)
-    uri = URI("http://localhost:#{:port}/v1/acl")
+    uri = URI("http://localhost:#{@resource[:port]}/v1/acl")
     http = Net::HTTP.new(uri.host, uri.port)
     acl_api_token = @resource[:acl_api_token]
     path = uri.request_uri + "/#{method}?token=#{acl_api_token}"
@@ -61,17 +82,13 @@ Puppet::Type.type(:consul_acl).provide(
     end
   end
 
-  def get_resource_id(name)
+  def get_resource(name, port)
     acl_api_token = @resource[:acl_api_token]
-    resources = self.class.list_resources(acl_api_token).select do |res|
+    resources = self.class.list_resources(acl_api_token, port).select do |res|
       res[:name] == name
     end
     # if the user creates multiple with the same name this will do odd things
-    if resources.first
-        return resources.first[:id]
-    else
-        return nil
-    end
+    resources.first || nil
   end
 
   def initialize(value={})
@@ -99,8 +116,10 @@ Puppet::Type.type(:consul_acl).provide(
       rules = ""
     end
     type = @resource[:type]
-    id = @resource[:id]
-    if id
+    port = @resource[:port]
+    acl = self.get_resource(name, port)
+    if acl
+      id = acl[:id]
       if @property_flush[:ensure] == :absent
         put_acl("destroy/#{id}", nil)
         return
@@ -111,10 +130,11 @@ Puppet::Type.type(:consul_acl).provide(
                           "rules" => "#{rules}" })
 
     else
-      put_acl('create', { "id"    => "#{id}",
+      put_acl('create', { "id"    => "#{@resource[:id]}",
                           "name"  => "#{name}",
                           "type"  => "#{type}",
                           "rules" => "#{rules}" })
     end
+    @property_hash.clear
   end
 end

--- a/lib/puppet/type/consul_acl.rb
+++ b/lib/puppet/type/consul_acl.rb
@@ -18,7 +18,7 @@ Puppet::Type.newtype(:consul_acl) do
     defaultto 'client'
   end
 
-  newproperty(:acl_api_token) do
+  newparam(:acl_api_token) do
     desc 'Token for accessing the ACL API'
     validate do |value|
       raise ArgumentError, "ACL API token must be a string" if not value.is_a?(String)
@@ -38,7 +38,7 @@ Puppet::Type.newtype(:consul_acl) do
     desc 'ID of token'
   end
 
-  newproperty(:port) do
+  newparam(:port) do
     desc 'consul port'
     value = 8500 if value.nil?
     validate do |value|


### PR DESCRIPTION
Implemented prefetch so that multiple puppet runs will not attempt to recreate the ACLs. Also fixed ACLs not working due to a typo introduced by the addition of the port parameter.

Note: I've only been playing with puppet for a couple of weeks so this isn't necessarily the best implementation. I'm also a bit uncomfortable about the reliance on 'port' and 'acl_api_token' needing to be correct across all tokens or bad things might happen. 