### PR TITLE
Add protocol option for ACL operations (http/https), defaults to http, like before

### DIFF
--- a/lib/puppet/provider/consul_acl/default.rb
+++ b/lib/puppet/provider/consul_acl/default.rb
@@ -10,6 +10,7 @@ Puppet::Type.type(:consul_acl).provide(
     resources.each do |name, resource|
       Puppet.debug("prefetching for #{name}")
       port = resource[:port]
+      protocol = resource[:protocol]
       token = resource[:acl_api_token]
 
       found_acls = list_resources(token, port).select do |acl|
@@ -34,7 +35,7 @@ Puppet::Type.type(:consul_acl).provide(
 
     # this might be configurable by searching /etc/consul.d
     # but would break for anyone using nonstandard paths
-    uri = URI("http://localhost:#{port}/v1/acl")
+    uri = URI("#{protocol}://localhost:#{port}/v1/acl")
     http = Net::HTTP.new(uri.host, uri.port)
 
     path=uri.request_uri + "/list?token=#{acl_api_token}"
@@ -68,7 +69,7 @@ Puppet::Type.type(:consul_acl).provide(
   end
 
   def put_acl(method,body)
-    uri = URI("http://localhost:#{@resource[:port]}/v1/acl")
+    uri = URI("#{@resource[:protocol]}://localhost:#{@resource[:port]}/v1/acl")
     http = Net::HTTP.new(uri.host, uri.port)
     acl_api_token = @resource[:acl_api_token]
     path = uri.request_uri + "/#{method}?token=#{acl_api_token}"

--- a/lib/puppet/type/consul_acl.rb
+++ b/lib/puppet/type/consul_acl.rb
@@ -38,6 +38,12 @@ Puppet::Type.newtype(:consul_acl) do
     desc 'ID of token'
   end
 
+  newproperty(:protocol) do
+    desc 'consul protocol'
+    newvalues('http', 'https')
+    defaultto 'http'
+  end
+
   newparam(:port) do
     desc 'consul port'
     defaultto 8500

--- a/spec/unit/puppet/type/consul_acl_spec.rb
+++ b/spec/unit/puppet/type/consul_acl_spec.rb
@@ -42,5 +42,9 @@ describe Puppet::Type.type(:consul_acl) do
     it 'should accept a hash of rules' do
       expect(@acl[:rules]).to eq(samplerules)
     end
+
+    it 'should default to http' do
+      expect(@acl[:protocol]).to eq(:http)
+    end
   end
 end


### PR DESCRIPTION
Fixes #217