### PR TITLE
Debian init script should depend on networking, resolution and syslog

### DIFF
--- a/templates/consul.debian.erb
+++ b/templates/consul.debian.erb
@@ -1,8 +1,8 @@
 #! /bin/sh
 ### BEGIN INIT INFO
 # Provides:          consul
-# Required-Start:    $local_fs $remote_fs
-# Required-Stop:     $local_fs $remote_fs
+# Required-Start:    $local_fs $remote_fs $syslog $named $network
+# Required-Stop:     $local_fs $remote_fs $syslog $named $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      S 0 1 6
 # Short-Description: Consul service discovery framework


### PR DESCRIPTION
I've had these changes sitting out in a branch for a while and have been meaning to submit them back.

I noticed we had issues with Consul starting in the wrong order on our systems - primarily because we were using syslog for logging and the syslog daemon hadn't been started by the time Debian had decided to start Consul.