### PR TITLE
lazily return nil when consul client isn't installed

### DIFF
--- a/lib/facter/consul_version.rb
+++ b/lib/facter/consul_version.rb
@@ -3,8 +3,10 @@
 Facter.add(:consul_version) do
   confine :kernel => 'Linux'
   setcode do
-    version = Facter::Util::Resolution.exec('consul --version 2> /dev/null')
-    version = version.lines.first.split[1].tr('v','')
-    version
+    begin
+      Facter::Util::Resolution.exec('consul --version 2> /dev/null').lines.first.split[1].tr('v','')
+    rescue
+      nil
+    end
   end
 end


### PR DESCRIPTION
This patch fixes the following error which occurs when consul isn't installed on a client:

```
Error: Facter: error while resolving custom fact "consul_version": undefined method `lines' for nil:NilClass
```