### PR TITLE
Fix fact when consul isn't installed

### DIFF
--- a/lib/facter/consul_version.rb
+++ b/lib/facter/consul_version.rb
@@ -3,8 +3,8 @@
 Facter.add(:consul_version) do
   confine :kernel => 'Linux'
   setcode do
-    version = Facter::Util::Resolution.exec('consul --version 2> /dev/null')
-    version = version.lines.first.split[1].tr('v','')
+    version = Facter::Util::Resolution.exec('consul --version 2> /dev/null').lines.first.split[1].tr('v','')
+    version = version.lines.first.split[1].tr('v','') unless version.nil?
     version
   end
 end


### PR DESCRIPTION
If consul isn't installed, I get the a nil:NilClass error:

```
Could not retrieve fact='consul_version', resolution='<anonymous>': undefined method `lines' for nil:NilClass
```

This fixes that.