### PR TITLE
Added custom init style "custom"

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -78,9 +78,6 @@ class consul::config(
           content => template('consul/consul.launchd.erb')
         }
       }
-      'custom' : {
-        notice("I'm not creating an init script for you as you are going to create one yourself")
-      }
       default : {
         fail("I don't know how to create an init script for style ${consul::init_style}")
       }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -78,6 +78,9 @@ class consul::config(
           content => template('consul/consul.launchd.erb')
         }
       }
+      'custom' : {
+        notice("I'm not creating an init script for you as you are going to create one yourself")
+      }
       default : {
         fail("I don't know how to create an init script for style ${consul::init_style}")
       }

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -10,7 +10,7 @@ class consul::run_service {
     default   => 'consul',
   }
 
-  if $consul::manage_service == true {
+  if $consul::manage_service == true and $consul::init_style != 'custom' {
     service { 'consul':
       ensure => $consul::service_ensure,
       name   => $init_selector,

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -10,7 +10,7 @@ class consul::run_service {
     default   => 'consul',
   }
 
-  if $consul::manage_service == true and $consul::init_style != 'custom' {
+  if $consul::manage_service == true and $consul::init_style {
     service { 'consul':
       ensure => $consul::service_ensure,
       name   => $init_selector,


### PR DESCRIPTION
This is useful for scenarios when you want to start consul from another program manager, e.g supervisor (supervisord.org).

Full example:
  class { 'consul':
    package_ensure => $package_ensure,
    config_hash        => $config_hash,
    init_style             => 'custom',
  }

  supervisor::program { 'consul':
    command   => '/usr/local/bin/consul agent -config-dir /usr/local/consul/conf',
    user            => 'consul',
    group          => 'consul',
  }

This change will prevent puppet-consul from creating an init script and managing the process, so the supervisor could do this instead.