### PR TITLE
Fix a puppet 2.7 compatibility issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,11 @@ end
 
 group :test do
   gem "json"
-  gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
   gem "puppet-lint"
 
   # Pin for 1.8.7 compatibility for now
+  gem "rake", "< 11.0.0"
   gem "rspec", '< 3.2.0'
   gem "rspec-core", "3.1.7"
   gem "rspec-puppet", "~> 2.1"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,16 +25,19 @@ class consul::install {
       staging::extract { "consul-${consul::version}.${consul::download_extension}":
         target  => "${::staging::path}/consul-${consul::version}",
         creates => "${::staging::path}/consul-${consul::version}/consul",
-      } ->
+      }
+
       file {
         "${::staging::path}/consul-${consul::version}/consul":
-          owner => 'root',
-          group => 0, # 0 instead of root because OS X uses "wheel".
-          mode  => '0555';
+          owner   => 'root',
+          group   => 0, # 0 instead of root because OS X uses "wheel".
+          mode    => '0555',
+          require => Staging::Extract["consul-${consul::version}.${consul::download_extension}"];
         "${consul::bin_dir}/consul":
           ensure => link,
           notify => $consul::notify_service,
-          target => "${::staging::path}/consul-${consul::version}/consul";
+          target => "${::staging::path}/consul-${consul::version}/consul",
+          require => Staging::Extract["consul-${consul::version}.${consul::download_extension}"];
       }
 
       if ($consul::ui_dir and $consul::data_dir) {


### PR DESCRIPTION
It seems that `-> file` doesn't work if multiple `file` resources are specified within the same block. On puppet 2.7.10, I get the following error:

```
Could not find resource 'File[/opt/staging/consul-0.6.3/consul]File[/usr/local/bin/consul]' for relationship from 'Staging::Extract[consul-0.6.3.zip]'
```