### PR TITLE
Changing systemd script due missing environment

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,6 +34,12 @@ class consul::config(
         }
       }
       'systemd' : {
+        file { '/etc/sysconfig/consul':
+          ensure  => directory,
+          mode    => '0644',
+          owner   => 'root',
+          group   => 'root',
+        }->
         file { '/lib/systemd/system/consul.service':
           mode    => '0644',
           owner   => 'root',

--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -1,16 +1,14 @@
 [Unit]
-Description=Consul Agent
-Wants=basic.target
-After=basic.target network.target
+Description=Consul agent
+Requires=network-online.target
+After=network-online.target
 
 [Service]
-User=<%= scope.lookupvar('consul::user') %>
-Group=<%= scope.lookupvar('consul::group') %>
-ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent \
-  -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>
-ExecReload=/bin/kill -HUP $MAINPID
-KillMode=process
+EnvironmentFile=-/etc/sysconfig/consul
 Restart=on-failure
+ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent -config-dir=<%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGINT
 RestartSec=42s
 LimitNOFILE=131072
 


### PR DESCRIPTION
hi
I have decided that systemd template has missed environment option , about user and group section we can discuss why to put there user and group credentials ?

Regards 
Karen