### PR TITLE
Remove undef values from the tags array

### DIFF
--- a/lib/puppet/parser/functions/consul_sorted_json.rb
+++ b/lib/puppet/parser/functions/consul_sorted_json.rb
@@ -21,7 +21,7 @@ module JSON
           end
           return "{" << ret.join(",") << "}";
         else
-          raise Exception("Unable to handle object of type <%s>" % obj.class.to_s)
+          raise Exception.new("Unable to handle object of type <%s>" % obj.class.to_s)
       end
     end
 
@@ -67,7 +67,7 @@ module JSON
 
           return "{\n" << ret.join(",\n") << "\n#{indent * @@loop}}";
         else
-          raise Exception("Unable to handle object of type <%s>" % obj.class.to_s)
+          raise Exception.new("Unable to handle object of type <%s>" % obj.class.to_s)
       end
 
     end # end def

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -44,12 +44,14 @@ define consul::service(
 
   consul_validate_checks($checks)
 
+  $use_tags = delete_undef_values($tags)
+
   $basic_hash = {
     'id'      => $id,
     'name'    => $service_name,
     'address' => $address,
     'port'    => $port,
-    'tags'    => $tags,
+    'tags'    => $use_tags,
     'checks'  => $checks,
     'token'   => $token,
   }


### PR DESCRIPTION
Two minor fixes:

`raise Exception("")` doesn't seem to work in ruby 1.9 or 2.x but `raise Exception.new('')` does

```
irb(main):003:0> raise Exception("Unable to handle object of type <%s>" % obj.class.to_s)
NoMethodError: undefined method `Exception' for main:Object
	from (irb):3

irb(main):004:0> raise Exception.new("Unable to handle object of type <%s>" % obj.class.to_s)
Exception: Unable to handle object of type <String>
	from (irb):4
```

The second fix happens when you pass an undef inside the  `$tags` variable. This causes consul_sorted_json to throw an exception. delete_undef_values doesn't seem to be able to remove the undef from the tags array inside the `$basic_hash` hash.

Explicitly running delete_undef_values on the tags fixes the issue.
