### PR TITLE
new condition and gid reference added to user

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -99,21 +99,31 @@ class consul::install {
     }
   }
 
-  if $consul::manage_user {
+  if $consul::manage_user and $consul::manage_group {
     user { $consul::user:
       ensure => 'present',
       system => true,
+      gid    => $consul::group,
       groups => $consul::extra_groups,
     }
-
-    if $consul::manage_group {
-      Group[$consul::group] -> User[$consul::user]
-    }
-  }
-  if $consul::manage_group {
     group { $consul::group:
       ensure => 'present',
       system => true,
+    }
+    Group[$consul::group] -> User[$consul::user]
+  } else {
+    if $consul::manage_user {
+      user { $consul::user:
+        ensure => 'present',
+        system => true,
+        groups => $consul::extra_groups,
+      }
+    }
+    if $consul::manage_group {
+      group { $consul::group:
+        ensure => 'present',
+        system => true,
+      }
     }
   }
 }


### PR DESCRIPTION
#236 Problem is that when adding a user and a group the user needs to be added with the gid to the group.

Solution added a new condition when manage_user and manage_group is true. The group created is added to the user during the creation of user. If the condition is not met the resources will be created same way as before.

Tested on Debian and Centos.