### PR TITLE
Use redhat init instead of "init" init

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,7 +38,7 @@ class consul::params {
     }
   } elsif $::operatingsystem =~ /Scientific|CentOS|RedHat|OracleLinux/ {
     if versioncmp($::operatingsystemrelease, '7.0') < 0 {
-      $init_style = 'init'
+      $init_style = 'redhat'
     } else {
       $init_style  = 'systemd'
     }


### PR DESCRIPTION
https://docs.puppetlabs.com/puppet/3.8/reference/types/service.html#service-provider-redhat

I had CentOS 6 nodes in an autoscaling group.  When they would get scaled down/terminated, consul would show them as failed.  I had leave_on_terminate set to true, but I was still seeing the error.  When I ran chkconfig on the box, the consul service wasn't listed.  So, the K20consul script was not getting called in /etc/rc6.d and the node wasn't leaving the cluster.  Please correct me if I'm wrong, but I suspect this provider is the right one for the operatingsystem entries listed.  Also, is this even necessary as puppet is supposed to pick the "best" init_style for a service anyway.  Should most of these elsif entries just be removed?