### PR TITLE
in dynamic environment consul-agent should be init

### DIFF
--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -10,7 +10,7 @@ ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent \
   -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
-Restart=on-failure
+Restart=always
 RestartSec=42s
 LimitNOFILE=131072
 


### PR DESCRIPTION
I modified this value in my puppet repo after check consul-agent was finished with clean exit or somethig of these signals SIGHUP, SIGINT, SIGTERM or SIGPIPE

I need consul is always working in live "nodes"

I also read this documentation: https://www.freedesktop.org/software/systemd/man/systemd.service.html