### PR TITLE
Puppet archive install directory will fail if default umask changed

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,6 +29,9 @@ class consul::install {
         $install_path,
         "${install_path}/consul-${consul::version}"]:
         ensure => directory,
+        owner  => 'root',
+        group  => 0, # 0 instead of root because OS X uses "wheel".
+        mode   => '0555';
       }->
       archive { "${install_path}/consul-${consul::version}.${consul::download_extension}":
         ensure       => present,


### PR DESCRIPTION
This fix will ensure the directory is always available to the consul user, I've observed this issue when securing a server and setting a default umask 077 rather than the more permissive umask 022.