### PR TITLE
adding ability to define the inital status of consul checks

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -54,6 +54,7 @@ define consul::check(
   $timeout    = undef,
   $notes      = undef,
   $token      = undef,
+  $status     = undef,
 ) {
   include consul
 
@@ -69,6 +70,7 @@ define consul::check(
     'service_id' => $service_id,
     'notes'      => $notes,
     'token'      => $token,
+    'status'     => $status,
   }
 
   $check_hash = {

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -42,6 +42,10 @@
 # [*token*]
 #   ACL token for interacting with the catalog (must be 'management' type)
 #
+# [*status*]
+#   The default state of the check when it is registered against a consul
+#   agent. Should be either "critical" or "passing"
+#
 define consul::check(
   $ensure     = present,
   $id         = $title,


### PR DESCRIPTION
Would like to add the ability to define the inital check status as described in https://www.consul.io/docs/agent/checks.html under the heading "Initial Health Check Status".

I've tested this change and it works.