### PR TITLE
Drop ruby 1.8 support again now that puppet-archive doesn't support it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install: rm Gemfile.lock || true
 sudo: false
 cache: bundler
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
@@ -38,12 +37,8 @@ matrix:
     env: PUPPET_VERSION="~> 3.4.0"
   - rvm: 1.9.3
     env: PUPPET_VERSION="~> 4.0.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0.0"
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 4.0.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.1.0"
   - rvm: 1.9.3
     env: PUPPET_VERSION="~> 4.1.0"
   - rvm: 2.0.0


### PR DESCRIPTION
cc @duritong 

The tests are failing again because puppet-archive no longer supports ruby 1.8.

The world is moving past this ruby, puppetlabs no longer support it and neither do our dependencies.

I would like to drop support for this unless you want to go through the effort to support it in puppet-archive.

See also:
https://github.com/voxpupuli/plumbing/issues/36
