### PR TITLE
Handle nested :undef in consul_sorted_json

### DIFF
--- a/lib/puppet/parser/functions/consul_sorted_json.rb
+++ b/lib/puppet/parser/functions/consul_sorted_json.rb
@@ -6,7 +6,7 @@ module JSON
 
     def sorted_generate(obj)
       case obj
-        when NilClass,Fixnum, Float, TrueClass, FalseClass,String
+        when NilClass, :undef, Fixnum, Float, TrueClass, FalseClass, String
           return simple_generate(obj)
         when Array
           arrayRet = []
@@ -21,7 +21,7 @@ module JSON
           end
           return "{" << ret.join(",") << "}";
         else
-          raise Exception("Unable to handle object of type <%s>" % obj.class.to_s)
+          raise Exception.new("Unable to handle object of type #{obj.class.name} with value #{obj.inspect}")
       end
     end
 
@@ -67,7 +67,7 @@ module JSON
 
           return "{\n" << ret.join(",\n") << "\n#{indent * @@loop}}";
         else
-          raise Exception("Unable to handle object of type <%s>" % obj.class.to_s)
+          raise Exception.new("Unable to handle object of type #{obj.class.name} with value #{obj.inspect}")
       end
 
     end # end def
@@ -75,7 +75,7 @@ module JSON
     # simplify jsonification of standard types
     def simple_generate(obj)
       case obj
-        when NilClass
+        when NilClass, :undef
           'null'
         when Fixnum, Float, TrueClass, FalseClass
           "#{obj}"
@@ -154,8 +154,6 @@ Optionally you can pass 2 additional parameters, pretty generate and indent leng
     unsorted_hash = args[0]      || {}
     pretty        = args[1]      || false
     indent_len    = args[2].to_i || 4
-
-    unsorted_hash.reject! {|key, value| value == :undef }
 
     if pretty
       return JSON.sorted_pretty_generate(unsorted_hash, indent_len) << "\n"

--- a/spec/functions/consul_sorted_json_spec.rb
+++ b/spec/functions/consul_sorted_json_spec.rb
@@ -4,10 +4,13 @@ RSpec.shared_examples 'handling_simple_types' do |pretty|
   it 'handles nil' do
     expect(subject.call([ {'key' => nil }],pretty)).to eql('{"key":null}')
   end
+  it 'handles :undef' do
+    expect(subject.call([ {'key' => :undef }],pretty)).to eql('{"key":null}')
+  end
   it 'handles true' do
     expect(subject.call([{'key' => true }],pretty)).to eql('{"key":true}')
   end
-  it 'handles nil' do
+  it 'handles false' do
     expect(subject.call([{'key' => false }],pretty)).to eql('{"key":false}')
   end
   it 'handles positive integer' do
@@ -56,6 +59,18 @@ describe 'consul_sorted_json', :type => :puppet_function do
   it "validate ugly json" do
     json = subject.call([test_hash]) # pretty=false by default
     expect(json).to match("{\"a\":1,\"p\":2,\"s\":-7,\"z\":3}")
+  end
+
+  it "handles nested :undef values" do
+    nested_undef_hash = {
+      'key' => 'value',
+      'undef' => :undef,
+      'nested_undef' => {
+        'undef' => :undef
+      }
+    }
+    json = subject.call([nested_undef_hash])
+    expect(json).to match("{\"key\":\"value\",\"nested_undef\":{\"undef\":null},\"undef\":null}")
   end
 
   context 'nesting' do


### PR DESCRIPTION
Currently `consul_sorted_json` only handles top level `:undef` values,
leaving nested `:undef` values to slip through and eventually raise an
exception. Instead of trying to handle all `:undef`s upfront in the
function, handle them in the recursion and treat them as what they
actually are, `null`s.

I've also been encountering the `Exception("")` vs `Exception.new("")`
problem detailed in #245, as `Exception("")` is not valid syntax in
newer versions of Ruby. That fix is included here as well