### PR TITLE
Configure log file for upstart.

### DIFF
--- a/templates/consul.upstart.erb
+++ b/templates/consul.upstart.erb
@@ -10,6 +10,7 @@ env GROUP=<%= scope.lookupvar('consul::group') %>
 env DEFAULTS=/etc/default/consul
 env RUNDIR=/var/run/consul
 env PID_FILE=/var/run/consul/consul.pid
+env LOG_FILE=/var/log/consul
 env RPC_ADDR=-rpc-addr=<%= scope.lookupvar('consul::rpc_addr') %>:<%= scope.lookupvar('consul::rpc_port') %>
 
 pre-start script
@@ -25,6 +26,7 @@ script
     [ -e $DEFAULTS ] && . $DEFAULTS
 
     export GOMAXPROCS=${GOMAXPROCS:-2}
+    exec >> $LOG_FILE 2>&1
     exec start-stop-daemon -c $USER -g $GROUP -p $PID_FILE -x $CONSUL -S -- agent -config-dir $CONFIG -pid-file $PID_FILE <%= scope.lookupvar('consul::extra_options') %>
 end script
 


### PR DESCRIPTION
This PR configures a log file for the upstart configuration similar to the one for the [`init.d`](https://github.com/solarkennedy/puppet-consul/blob/master/templates/consul.init.erb#L19) configuration.

I tested this by provisioning a consul server with the new configuration and observing the log file being created log entries being appended. I restarted the service and the new entries were appended to the existing file.