### PR TITLE
Added KillSignal to gracefully halt agent

### DIFF
--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -9,7 +9,9 @@ Group=<%= scope.lookupvar('consul::group') %>
 ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent \
   -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
+<% if @config_hash["server"] == false -%>
 KillSignal=INT
+<% end -%>
 KillMode=process
 Restart=always
 RestartSec=42s

--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -9,6 +9,7 @@ Group=<%= scope.lookupvar('consul::group') %>
 ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent \
   -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=INT
 KillMode=process
 Restart=always
 RestartSec=42s


### PR DESCRIPTION
In order to use, in systemd service, kill procedure configuration _KillMode=process_ (default signal sent is _SIGTERM_ https://www.freedesktop.org/software/systemd/man/systemd.kill.html# ) and be able to stop consul agent gracefully. We would have to use configuration option _KillSignal_ sent _SIGINIT_ (https://www.consul.io/docs/agent/basics.html)
