### PR TITLE
add retry logic when contacting the REST API for listing ACL resources

### DIFF
--- a/lib/puppet/type/consul_acl.rb
+++ b/lib/puppet/type/consul_acl.rb
@@ -60,6 +60,14 @@ Puppet::Type.newtype(:consul_acl) do
     defaultto 'localhost'
   end
 
+  newparam(:api_tries) do
+    desc 'number of tries when contacting the Consul REST API'
+    defaultto 3
+    validate do |value|
+      raise ArgumentError, "Number of API tries must be a number" if not value.is_a?(Integer)
+    end
+  end
+
   autorequire(:service) do
     ['consul']
   end


### PR DESCRIPTION
Puppet catalog fails when Consul API is not available (500 error). Another Puppet run is needed if Consul has just been started previously in the process of applying the catalog.

Add retry logic so this is less likely to happen.