### PR TITLE
add retry logic when contacting the REST API for listing ACL resources

### DIFF
--- a/lib/puppet/type/consul_acl.rb
+++ b/lib/puppet/type/consul_acl.rb
@@ -60,6 +60,14 @@ Puppet::Type.newtype(:consul_acl) do
     defaultto 'localhost'
   end
 
+  newparam(:api_tries) do
+    desc 'number of tries when contacting the Consul REST API'
+    defaultto 3
+    validate do |value|
+      raise ArgumentError, "Number of API tries must be a number" if not value.is_a?(Integer)
+    end
+  end
+
   autorequire(:service) do
     ['consul']
   end


### PR DESCRIPTION
Add a simple retry loop when querying the REST API for building ACL resources, and add resource param `api_tries` for adjusting the number of retries. Should fix #193.

(Also add `protocol` argument to these methods -- somehow when I was working with this, a bug came up where it started complaining about `protocol` being missing, and I didn't see how it could have done without it in the past. Please let me know if this needs fixing, or separating to a different PR ...)