### PR TITLE
Allow for stable versions of puppet/archive

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">=0.5.0 <1.0.0"
+      "version_requirement": ">=0.5.0 <2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Without this patch, the current metadata instructs that only unstable versions before 1.0.0 are supported. Since those versions allow for breaking changes, we should allow for the stable v1.