### PR TITLE
Drop pinning for 1.8.7 as there are no tests for it anymore.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,17 +11,17 @@ group :development do
 end
 
 group :test do
+  # Pin for 1.9.3 compatibility for now
   gem "json", '~> 1.8.3'
   gem "json_pure", '~> 1.8.3'
-  # Pin for 1.8.7 compatibility for now
-  gem "rake", '< 11.0.0'
+
+  gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
   gem "puppet-lint"
 
-  # Pin for 1.8.7 compatibility for now
-  gem "rspec", '< 3.2.0'
-  gem "rspec-core", "3.1.7"
-  gem "rspec-puppet", "~> 2.1"
+  gem "rspec"
+  gem "rspec-core"
+  gem "rspec-puppet"
 
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"


### PR DESCRIPTION
29a9b55 dropped tests for ruby 1.8.7 so the pinning is no longer required.