### PR TITLE
Remove puppet error when ACLs cannot be retrieved

### DIFF
--- a/lib/puppet/provider/consul_acl/default.rb
+++ b/lib/puppet/provider/consul_acl/default.rb
@@ -57,7 +57,9 @@ Puppet::Type.type(:consul_acl).provide(
     if res.code == '200'
       acls = JSON.parse(res.body)
     else
-      raise(Puppet::Error,"Cannot retrieve ACLs: invalid return code #{res.code} uri: #{path} body: #{req.body}")
+      Puppet.warning("Cannot retrieve ACLs: invalid return code #{res.code} uri: #{path} body: #{req.body}")
+      $stderr.puts "Cannot retrieve ACLs: invalid return code #{res.code} uri: #{path} body: #{req.body}"
+      return {}
     end
 
     nacls = acls.collect do |acl|

--- a/lib/puppet/provider/consul_acl/default.rb
+++ b/lib/puppet/provider/consul_acl/default.rb
@@ -58,7 +58,6 @@ Puppet::Type.type(:consul_acl).provide(
       acls = JSON.parse(res.body)
     else
       Puppet.warning("Cannot retrieve ACLs: invalid return code #{res.code} uri: #{path} body: #{req.body}")
-      $stderr.puts "Cannot retrieve ACLs: invalid return code #{res.code} uri: #{path} body: #{req.body}"
       return {}
     end
 


### PR DESCRIPTION
Currently if consul does not come up or there is some issue electing a
leader, the consul_acl will throw a hard puppet error. This causes the
puppet run to immediately fail. This commit changes that puppet error to
a warning. The unavailability of the consul API should not cause a
puppet failure.