### PR TITLE
Catch :undef when pretty-printing in consul_sorted_json.rb

### DIFF
--- a/lib/puppet/parser/functions/consul_sorted_json.rb
+++ b/lib/puppet/parser/functions/consul_sorted_json.rb
@@ -31,7 +31,7 @@ module JSON
       indent = " " * indent_len
 
       case obj
-        when NilClass,Fixnum, Float, TrueClass, FalseClass,String
+        when NilClass, :undef, Fixnum, Float, TrueClass, FalseClass, String
           return simple_generate(obj)
         when Array
           arrayRet = []


### PR DESCRIPTION
This'll prevent an exception when an undef value gets assigned in `config_hash`.