### PR TITLE
KV Provider / Prepared Query Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,18 @@ consul_prepared_query { 'consul':
 
 This provider currently only has support for basic prepared queries (not templated queries).
 
+## Key/Value Objects
+
+```puppet
+consul_key_value { 'key/path':
+  ensure => 'present',
+  value  => 'myvaluestring',
+  flags  => 12345,
+}
+```
+
+This provider allows you to manage key/value pairs.
+
 ## Limitations
 
 Depends on the JSON gem, or a modern ruby. (Ruby 1.8.7 is not officially supported)

--- a/lib/puppet/provider/consul_key_value/default.rb
+++ b/lib/puppet/provider/consul_key_value/default.rb
@@ -1,0 +1,154 @@
+require 'json'
+require 'net/http'
+require 'uri'
+require 'base64'
+Puppet::Type.type(:consul_key_value).provide(
+  :default
+) do
+  mk_resource_methods
+
+  def self.prefetch(resources)
+    resources.each do |name, resource|
+      Puppet.debug("prefetching for #{name}")
+      port = resource[:port]
+      hostname = resource[:hostname]
+      protocol = resource[:protocol]
+      token = resource[:acl_api_token]
+      tries = resource[:api_tries]
+
+      found_key_values = list_resources(token, port, hostname, protocol, tries).select do |key_value|
+        key_value[:name] == name
+      end
+
+      found_key_value = found_key_values.first || nil
+      if found_key_value
+        Puppet.debug("found #{found_key_value}")
+        resource.provider = new(found_key_value)
+      else
+        Puppet.debug("found none #{name}")
+        resource.provider = new({:ensure => :absent})
+      end
+    end
+  end
+
+  def self.list_resources(acl_api_token, port, hostname, protocol, tries)
+    if @key_values
+      return @key_values
+    end
+
+    # this might be configurable by searching /etc/consul.d
+    # but would break for anyone using nonstandard paths
+    uri = URI("#{protocol}://#{hostname}:#{port}/v1/kv/?recurse")
+    http = Net::HTTP.new(uri.host, uri.port)
+
+    path=uri.request_uri + "&token=#{acl_api_token}"
+    req = Net::HTTP::Get.new(path)
+    res = nil
+
+    # retry Consul API query for ACLs, in case Consul has just started
+    (1..tries).each do |i|
+      unless i == 1
+        Puppet.debug("retrying Consul API query in #{i} seconds")
+        sleep i
+      end
+      res = http.request(req)
+      break if res.code == '200'
+    end
+
+    if res.code == '200'
+      key_values = JSON.parse(res.body)
+
+    # No keys exists yet in this datacenter
+    elsif res.code == '404'
+      return []
+    else
+      Puppet.warning("Cannot retrieve key_values: invalid return code #{res.code} uri: #{path} body: #{req.body}")
+      return {}
+    end
+
+    nkey_values = key_values.collect do |key_value|
+      {
+        :name    => key_value["Key"],
+        :value   => (key_value["Value"] == nil ? '' : Base64.decode64(key_value["Value"])),
+        :flags   => Integer(key_value["Flags"]),
+        :ensure  => :present,
+      }
+    end
+    @key_values = nkey_values
+    nkey_values
+  end
+
+  def get_path(name)
+    uri = URI("#{@resource[:protocol]}://#{@resource[:hostname]}:#{@resource[:port]}/v1/kv/#{name}")
+    http = Net::HTTP.new(uri.host, uri.port)
+    acl_api_token = @resource[:acl_api_token]
+    return uri.request_uri + "?token=#{acl_api_token}", http
+  end
+
+  def create_or_update_key_value(name, value, flags)
+    path, http = get_path(name)
+    req = Net::HTTP::Put.new(path + "&flags=#{flags}")
+    req.body = value
+    res = http.request(req)
+    if res.code != '200'
+      raise(Puppet::Error,"Session #{name} create/update: invalid return code #{res.code} uri: #{path} body: #{req.body}")
+    end
+  end
+
+  def delete_key_value(name)
+    path, http = get_path(name)
+    req = Net::HTTP::Delete.new(path)
+    res = http.request(req)
+    if res.code != '200'
+      raise(Puppet::Error,"Session #{name} delete: invalid return code #{res.code} uri: #{path} body: #{req.body}")
+    end
+  end
+
+  def get_resource(name, port, hostname, protocol, tries)
+    acl_api_token = @resource[:acl_api_token]
+    resources = self.class.list_resources(acl_api_token, port, hostname, protocol, tries).select do |res|
+      res[:name] == name
+    end
+    # if the user creates multiple with the same name this will do odd things
+    resources.first || nil
+  end
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def flush
+    name = @resource[:name]
+    flags = @resource[:flags]
+    value = @resource[:value]
+    port = @resource[:port]
+    hostname = @resource[:hostname]
+    protocol = @resource[:protocol]
+    tries = @resource[:api_tries]
+    key_value = self.get_resource(name, port, hostname, protocol, tries)
+    if key_value
+      if @property_flush[:ensure] == :absent
+        delete_key_value(name)
+        return
+      end
+      create_or_update_key_value(name, value, flags)
+
+    else
+      create_or_update_key_value(name, value, flags)
+    end
+    @property_hash.clear
+  end
+end

--- a/lib/puppet/type/consul_key_value.rb
+++ b/lib/puppet/type/consul_key_value.rb
@@ -1,0 +1,67 @@
+Puppet::Type.newtype(:consul_key_value) do
+
+  desc <<-'EOD'
+  Manage a consul key value object.
+  EOD
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc 'Name of the key/value object'
+    validate do |value|
+      raise ArgumentError, "Key/value object name must be a string" if not value.is_a?(String)
+    end
+  end
+
+  newparam(:flags) do
+    desc 'Flags integer'
+    validate do |value|
+      raise ArgumentError, "The flags value must be an integer" if not value.is_a?(Integer)
+    end
+    defaultto 0
+  end
+
+  newparam(:value) do
+    desc 'The key value string'
+    validate do |value|
+      raise ArgumentError, "The key value must be a string" if not value.is_a?(String)
+    end
+  end
+
+  newparam(:acl_api_token) do
+    desc 'Token for accessing the ACL API'
+    validate do |value|
+      raise ArgumentError, "ACL API token must be a string" if not value.is_a?(String)
+    end
+    defaultto ''
+  end
+
+  newproperty(:protocol) do
+    desc 'consul protocol'
+    newvalues('http', 'https')
+    defaultto 'http'
+  end
+
+  newparam(:port) do
+    desc 'consul port'
+    defaultto 8500
+    validate do |value|
+      raise ArgumentError, "The port number must be a number" if not value.is_a?(Integer)
+    end
+  end
+
+  newparam(:hostname) do
+    desc 'consul hostname'
+    validate do |value|
+      raise ArgumentError, "The hostname must be a string" if not value.is_a?(String)
+    end
+    defaultto 'localhost'
+  end
+
+  newparam(:api_tries) do
+    desc 'number of tries when contacting the Consul REST API'
+    defaultto 3
+    validate do |value|
+      raise ArgumentError, "Number of API tries must be a number" if not value.is_a?(Integer)
+    end
+  end
+end

--- a/lib/puppet/type/consul_prepared_query.rb
+++ b/lib/puppet/type/consul_prepared_query.rb
@@ -39,7 +39,7 @@ Puppet::Type.newtype(:consul_prepared_query) do
     desc 'Failover to the nearest <n> datacenters'
     defaultto 0
     validate do |value|
-      raise ArgumentError, "Nearest failover datacenters must be an integer" if not value.is_a?(Integer)
+      raise ArgumentError, "Nearest <n> failover datacenters must be an integer" if not value.is_a?(Integer)
     end
   end
 

--- a/spec/unit/puppet/type/consul_key_value_spec.rb
+++ b/spec/unit/puppet/type/consul_key_value_spec.rb
@@ -1,0 +1,26 @@
+describe Puppet::Type.type(:consul_key_value) do
+
+  it 'should fail if no name is provided' do
+    expect do
+      Puppet::Type.type(:consul_key_value).new(:type => 'client')
+    end.to raise_error(Puppet::Error, /Title or name must be provided/)
+  end
+
+  context 'with query parameters provided' do
+    before :each do
+      @key_value = Puppet::Type.type(:consul_key_value).new(
+        :name  => 'sample/key',
+        :value => 'sampleValue',
+        :flags => 1,
+      )
+    end
+
+    it 'should default to localhost' do
+      expect(@key_value[:hostname]).to eq('localhost')
+    end
+
+    it 'should default to http' do
+      expect(@key_value[:protocol]).to eq(:http)
+    end
+  end
+end

--- a/spec/unit/puppet/type/consul_prepared_query_spec.rb
+++ b/spec/unit/puppet/type/consul_prepared_query_spec.rb
@@ -8,7 +8,7 @@ describe Puppet::Type.type(:consul_prepared_query) do
 
   context 'with query parameters provided' do
     before :each do
-      @acl = Puppet::Type.type(:consul_prepared_query).new(
+      @prepared_query = Puppet::Type.type(:consul_prepared_query).new(
         :name                 => 'testing',
         :token                => '',
         :service_name         => 'testing',
@@ -21,11 +21,11 @@ describe Puppet::Type.type(:consul_prepared_query) do
     end
 
     it 'should default to localhost' do
-      expect(@acl[:hostname]).to eq('localhost')
+      expect(@prepared_query[:hostname]).to eq('localhost')
     end
 
     it 'should default to http' do
-      expect(@acl[:protocol]).to eq(:http)
+      expect(@prepared_query[:protocol]).to eq(:http)
     end
   end
 end


### PR DESCRIPTION
This adds a new KV provider for accessing the Key/Value database API. This also attempts to address issues in the previous Prepared Query PR and the following issues:
 
  - https://github.com/solarkennedy/puppet-consul/issues/291