### PR TITLE
Use `hiera_hash` with `create_resources`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -233,19 +233,19 @@ class consul (
   }
 
   if $services {
-    create_resources(consul::service, $services)
+    create_resources(consul::service, hiera_hash('consul::services', $services))
   }
 
   if $watches {
-    create_resources(consul::watch, $watches)
+    create_resources(consul::watch, hiera_hash('consul::watches', $watches)))
   }
 
   if $checks {
-    create_resources(consul::check, $checks)
+    create_resources(consul::check, hiera_hash('consul::checks', $checks))
   }
 
   if $acls {
-    create_resources(consul_acl, $acls)
+    create_resources(consul_acl, hiera_hash('consul::acls', $acls))
   }
 
   $notify_service = $restart_on_change ? {


### PR DESCRIPTION
Use the `hiera_hash` function together with `create_resources` for the `$consul::acls`, `$consul::checks`, `$consul::services` and `$consul::watches` parameters. This allows these resources to be defined in multiple levels of the Hiera hierachy.