### PR TITLE
add support for prepared query templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ consul_prepared_query { 'consul':
   service_failover_dcs => [ 'dc1', 'dc2' ],
   service_only_passing => true,
   service_tags         => [ '${match(2)}' ], # lint:ignore:single_quote_string_with_variables
+  template             => true,
   template_regexp      => '^consul-(.*)-(.*)$',
   template_type        => 'name_prefix_match',
 }

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ ACLs if the anonymous token doesn't permit ACL changes (which is likely).
 The api token may be the master token, another management token, or any
 client token with sufficient privileges.
 
-## Prepared Queries
+## Prepared Queries and Prepared Query Templates
 
 ```puppet
 consul_prepared_query { 'consul':
@@ -215,7 +215,21 @@ consul_prepared_query { 'consul':
 }
 ```
 
-This provider currently only has support for basic prepared queries (not templated queries).
+or a prepared query template:
+
+```puppet
+consul_prepared_query { 'consul':
+  ensure               => 'present',
+  service_name         => 'consul',
+  service_name         => 'consul-${match(1)}' # lint:ignore:single_quote_string_with_variables
+  service_failover_n   => 1,
+  service_failover_dcs => [ 'dc1', 'dc2' ],
+  service_only_passing => true,
+  service_tags         => [ '${match(2)}' ], # lint:ignore:single_quote_string_with_variables
+  template_regexp      => '^consul-(.*)-(.*)$',
+  template_type        => 'name_prefix_match',
+}
+```
 
 ## Key/Value Objects
 

--- a/lib/puppet/provider/consul_prepared_query/default.rb
+++ b/lib/puppet/provider/consul_prepared_query/default.rb
@@ -158,6 +158,8 @@ Puppet::Type.type(:consul_prepared_query).provide(
     hostname = @resource[:hostname]
     protocol = @resource[:protocol]
     tries = @resource[:api_tries]
+    template_regexp = @resource[:template_regexp]
+    template_type = @resource[:template_type]
     prepared_query = self.get_resource(name, port, hostname, protocol, tries)
     if prepared_query
       id = prepared_query[:id]
@@ -179,7 +181,12 @@ Puppet::Type.type(:consul_prepared_query).provide(
         },
         "DNS"    => {
           "TTL" => "#{ttl}s"
-        }})
+        },
+        "Template" => {
+          "Type"   => template_type,
+          "Regexp" => template_regexp,
+        }
+      })
 
     else
       create_prepared_query({
@@ -196,7 +203,12 @@ Puppet::Type.type(:consul_prepared_query).provide(
         },
         "DNS"    => {
           "TTL" => "#{ttl}s"
-        }})
+        },
+        "Template" => {
+          "Type"   => template_type,
+          "Regexp" => template_regexp,
+        }
+      })
     end
     @property_hash.clear
   end

--- a/lib/puppet/type/consul_prepared_query.rb
+++ b/lib/puppet/type/consul_prepared_query.rb
@@ -1,3 +1,5 @@
+require 'puppet/parameter/boolean'
+
 Puppet::Type.newtype(:consul_prepared_query) do
 
   desc <<-'EOD'
@@ -109,8 +111,14 @@ Puppet::Type.newtype(:consul_prepared_query) do
     end
   end
 
+  newparam(:template, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc 'is template?'
+    defaultto false
+  end
+
   newparam(:template_regexp) do
     desc 'regexp for template'
+    defaultto ''
     validate do |value|
       raise ArgumentError, "The template regexp must be a string" if not value.is_a?(String)
     end
@@ -118,6 +126,7 @@ Puppet::Type.newtype(:consul_prepared_query) do
 
   newparam(:template_type) do
     desc 'type for template'
+    defaultto 'name_prefix_match'
     validate do |value|
       raise ArgumentError, "The template type must be a string" if not value.is_a?(String)
     end

--- a/lib/puppet/type/consul_prepared_query.rb
+++ b/lib/puppet/type/consul_prepared_query.rb
@@ -108,4 +108,18 @@ Puppet::Type.newtype(:consul_prepared_query) do
       raise ArgumentError, "Number of API tries must be a number" if not value.is_a?(Integer)
     end
   end
+
+  newparam(:template_regexp) do
+    desc 'regexp for template'
+    validate do |value|
+      raise ArgumentError, "The template regexp must be a string" if not value.is_a?(String)
+    end
+  end
+
+  newparam(:template_type) do
+    desc 'type for template'
+    validate do |value|
+      raise ArgumentError, "The template type must be a string" if not value.is_a?(String)
+    end
+  end
 end


### PR DESCRIPTION
Expanding on https://github.com/solarkennedy/puppet-consul/pull/288 and the good work by @djtaylor, add support for prepared query templates to the custom type.

