### PR TITLE
Set login shell for consul user to /sbin/nologin

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -108,6 +108,7 @@ class consul::install {
     user { $::consul::user:
       ensure => 'present',
       system => true,
+      shell  => '/sbin/nologin',
       groups => $::consul::extra_groups,
     }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -215,7 +215,11 @@ describe 'consul' do
   end
 
   context "By default, a user and group should be installed" do
-    it { should contain_user('consul').with(:ensure => :present) }
+    it { should contain_user('consul').with(
+      :ensure => :present,
+      :system => true,
+      :shell  => '/sbin/nologin',
+    )}
     it { should contain_group('consul').with(:ensure => :present) }
   end
 


### PR DESCRIPTION
This addresses #293 - explicitly set login shell to `/sbin/nologin`, to satisfy CIS compliance failure.