### PR TITLE
Fixing init service start/stop messages and locks

### DIFF
--- a/templates/consul.init.erb
+++ b/templates/consul.init.erb
@@ -54,9 +54,10 @@ start() {
         [ -f $PID_FILE ] && rm $PID_FILE
         daemon --user=<%= scope.lookupvar('consul::user') %> \
             --pidfile="$PID_FILE" \
-            "$CONSUL" agent -pid-file "${PID_FILE}" -config-dir "$CONFIG" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE" &
+            $("$CONSUL" agent -pid-file "${PID_FILE}" -config-dir "$CONFIG" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE" &)
         retcode=$?
-        touch /var/lock/subsys/consul
+        echo
+        [ $retcode = 0 ] && touch /var/lock/subsys/consul
         return $retcode
 }
 
@@ -95,8 +96,8 @@ stop() {
         # killproc with no arguments uses TERM, then escalates to KILL.
         killproc $KILLPROC_OPT $CONSUL
         retcode=$?
-
-        rm -f /var/lock/subsys/consul $PID_FILE
+        echo
+        [ $retcode = 0 ] && rm -f /var/lock/subsys/consul $PID_FILE
         return $retcode
 }
 


### PR DESCRIPTION
- Don't send service start 'OK' to log file
- Make sure service end 'OK' gets printed
- Only remove lock and pid_file if service start/stop is successful