### PR TITLE
Cleanup Systemd unit file

### DIFF
--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -8,6 +8,7 @@ Group=<%= scope.lookupvar('consul::group') %>
 ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent \
   -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=INT
 Restart=always
 LimitNOFILE=131072
 

--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -1,7 +1,6 @@
 [Unit]
 Description=Consul Agent
-Wants=basic.target
-After=basic.target network.target
+After=network.target
 
 [Service]
 User=<%= scope.lookupvar('consul::user') %>
@@ -9,9 +8,7 @@ Group=<%= scope.lookupvar('consul::group') %>
 ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent \
   -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
-KillMode=process
 Restart=always
-RestartSec=5s
 LimitNOFILE=131072
 
 [Install]


### PR DESCRIPTION
Prompted by @solarkennedy’s [reply](https://github.com/solarkennedy/puppet-consul/commit/24931c85f9257d42f5f921d047a1b51ec43cf03e#commitcomment-20064308), here is how I think the Systemd unit file should look.

One thing that is not addressed in the very detailed commit message is the request for “some good data on what [the value of `RestartSec`] *should* be”. My reasoning for removing this option and keeping the default is as follows:

1. My intuition tells me that we want to respawn Consul immediately on failure, without any delay. This would have meant setting `RestartSec=0ms`.

1. The creators of Systemd, and Systemd itself by extension, are notorious for being very opinionated. If they deemed that the default should be 100ms and not 0ms, and given that I don’t have data to support my preference, I will rather trust their judgement.

The full commit message follows:

> Remove references to basic.target: Systemd automatically adds
> dependencies of the types Requires= and After= for this target unit to
> all services, so KISS and DRY.
> 
> Remove KillMode= option: Consul itself runs entirely in one process, so
> the default of killing all processes in the control group would not make
> a difference. If Consul does spawn processes, e.g. for health checks,
> the previous setting would have left them running behind when the
> service is stopped.
> 
> Remove RestartSec= option: There is no reason to override the default of
> 100ms.