### PR TITLE
Check $::consul_version more correctly

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,7 +18,7 @@ class consul::install {
       $install_path = $::consul::archive_path
 
       # only notify if we are installing a new version (work around for switching to archive module)
-      if $::consul_version != $::consul::version {
+      if getvar('$::consul_version') != $::consul::version {
         $do_notify_service = $::consul::notify_service
       } else {
         $do_notify_service = undef


### PR DESCRIPTION
If we are using puppet-consul to download and install consul for us, initially `$::consul_version` will be undefined (because no executable could be found). This change makes the version check fail so we proceed with an installation (but without a puppet undefined variable error, which halts execution entirely, causing installation to fail).

There might be a better way to solve this, but it's been working for me. :)