### PR TITLE
More Systemd unit file improvements

### DIFF
--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -8,7 +8,6 @@ Group=<%= scope.lookupvar('consul::group') %>
 ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent \
   -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
-KillSignal=INT
 Restart=always
 LimitNOFILE=131072
 

--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -8,7 +8,7 @@ Group=<%= scope.lookupvar('consul::group') %>
 ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent \
   -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
-Restart=always
+Restart=on-failure
 LimitNOFILE=131072
 
 [Install]


### PR DESCRIPTION
Since the merge of #301, I [learned some more](https://github.com/solarkennedy/puppet-consul/issues/282#issuecomment-268473999) about Consul’s defaults, and I also stumbled upon an example systemd.service file [inside the official consul repository](https://github.com/hashicorp/consul/blob/6f0a3b9bf5c7fd0673213d451bbc9e66f7a9cad9/terraform/shared/scripts/rhel_consul.service).

In the example unit file, the option is set to `Restart=on-failure`, so I decided to align with that, and let a human operator shut the agent down manually with a kill signal, rather than having to always use `systemctl` for that.

The reason for changing `KillSignal` back to its default `SIGTERM` is explained in https://github.com/solarkennedy/puppet-consul/issues/282#issuecomment-268473999 – in short, it prevents admins from shooting themselves in the foot by unintentionally altering quorum size on server termination. Thanks to Consul developer Armon Dadgar for highlighting the issue.