### PR TITLE
Add support of custom log_file in sles and upstart init scripts

### DIFF
--- a/templates/consul.sles.erb
+++ b/templates/consul.sles.erb
@@ -22,7 +22,7 @@ rc_reset
 
 CONSUL_BIN=<%= scope.lookupvar('consul::bin_dir') %>/consul
 CONFIG_DIR=<%= scope.lookupvar('consul::config_dir') %>
-LOG_FILE=/var/log/consul
+LOG_FILE=<%= scope.lookupvar('consul::log_file') %>
 
 
 # read settings like GOMAXPROCS from "/etc/sysconfig/consul"

--- a/templates/consul.upstart.erb
+++ b/templates/consul.upstart.erb
@@ -10,7 +10,7 @@ env GROUP=<%= scope.lookupvar('consul::group') %>
 env DEFAULTS=/etc/default/consul
 env RUNDIR=/var/run/consul
 env PID_FILE=/var/run/consul/consul.pid
-env LOG_FILE=/var/log/consul
+env LOG_FILE=<%= scope.lookupvar('consul::log_file') %>
 env RPC_ADDR=-rpc-addr=<%= scope.lookupvar('consul::rpc_addr') %>:<%= scope.lookupvar('consul::rpc_port') %>
 
 pre-start script


### PR DESCRIPTION
Hi,
As configuration of custom log file location was introduced in #289 I'd like add it to sles and upstart init scripts too.