### PR TITLE
Better acl rules message

### DIFF
--- a/lib/puppet/type/consul_acl.rb
+++ b/lib/puppet/type/consul_acl.rb
@@ -32,6 +32,15 @@ Puppet::Type.newtype(:consul_acl) do
     validate do |value|
       raise ArgumentError, "ACL rules must be provided as a hash" if not value.is_a?(Hash)
     end
+
+    def is_to_s(value)
+      should_to_s(value)
+    end
+
+    def should_to_s(value)
+      require 'pp'
+      value.pretty_inspect
+    end
   end
 
   newproperty(:id) do


### PR DESCRIPTION
Rule values were looking something like this:
> rules: rules changed {'key' => {'' => {'policy' => 'read'}, 'othertree/qa2/' => {'policy' => 'write'}, 'testing/tree/qa2/' => {'policy' => 'write'}}} to 'keypolicywriteothertree/qa2/policywritetesting/tree/qa2/policywrite'

With this change, rule values show up as:
> rules: rules changed '{"key"=>
  {""=>{"policy"=>"write"},
   "othertree/qa2/"=>{"policy"=>"write"},
   "testing/tree/qa2/"=>{"policy"=>"write"}}}
' to '{"key"=>
  {""=>{"policy"=>"read"},
   "othertree/qa2/"=>{"policy"=>"write"},
   "testing/tree/qa2/"=>{"policy"=>"write"}}}
'