### PR TITLE
Ensure /usr/local/bin is in the path for consul binary

### DIFF
--- a/lib/facter/consul_version.rb
+++ b/lib/facter/consul_version.rb
@@ -3,10 +3,15 @@
 Facter.add(:consul_version) do
   confine :kernel => 'Linux'
   setcode do
+    original_path = ENV['PATH']
+    path = ENV.fetch('PATH') { '/bin:/usr/bin:/usr/local/bin' }
+    ENV['PATH'] = path + ':/usr/local/bin'
     begin
       Facter::Util::Resolution.exec('consul --version 2> /dev/null').lines.first.split[1].tr('v','')
     rescue
       nil
+    ensure
+      ENV['PATH'] = original_path
     end
   end
 end


### PR DESCRIPTION
Checks the current path prior to running the consul binary.

* If no PATH is set, then a default value is set that includes `/usr/local/bin`
* If PATH already includes `/usr/local/bin` then no change is made to the path
* Otherwise, `/usr/local/bin` is added to the PATH environment variable

Tested change on CentOS 6.8 and verified that it fixes the problem I had encountered documented in #290 