### PR TITLE
fix ::consul_version fact lookup during installation

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,7 +19,7 @@ class consul::install {
       $install_path = pick($::consul::archive_path, "${install_prefix}/archives")
 
       # only notify if we are installing a new version (work around for switching to archive module)
-      if getvar('$::consul_version') != $::consul::version {
+      if getvar('::consul_version') != $::consul::version {
         $do_notify_service = $::consul::notify_service
       } else {
         $do_notify_service = undef


### PR DESCRIPTION
getvar() is currently looking for a fact named ```$::consul_version``` instead of a fact named ```::consul_version```, this throws the following parser error:

```
Warning: Scope(Class[Consul::Install]): Could not look up qualified variable '$::consul_version'; class $ could not be found
```