### PR TITLE
In the event you role a single consul package you can no provide the single name for both

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -84,7 +84,7 @@ class consul::install {
         ensure => $::consul::package_ensure,
       }
 
-      if $::consul::ui_dir {
+      if $::consul::ui_dir and $::consul::package_name != $::consul::ui_package_name {
         package { $::consul::ui_package_name:
           ensure  => $::consul::ui_package_ensure,
           require => Package[$::consul::package_name]


### PR DESCRIPTION
- Removes the auto install of consul-ui when providing ui_dir and the package names are the
  same