### PR TITLE
[WIP] BREAKING - Consul 0.8.0 fixes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -218,18 +218,18 @@ class consul (
     warning('data_dir must be set to install consul web ui')
   }
 
-  if ($config_hash_real['ports'] and $config_hash_real['ports']['rpc']) {
-    $rpc_port = $config_hash_real['ports']['rpc']
+  if ($config_hash_real['ports'] and $config_hash_real['ports']['http']) {
+    $http_port = $config_hash_real['ports']['http']
   } else {
-    $rpc_port = 8400
+    $http_port = 8500
   }
 
-  if ($config_hash_real['addresses'] and $config_hash_real['addresses']['rpc']) {
-    $rpc_addr = $config_hash_real['addresses']['rpc']
+  if ($config_hash_real['addresses'] and $config_hash_real['addresses']['http']) {
+    $http_addr = $config_hash_real['addresses']['http']
   } elsif ($config_hash_real['client_addr']) {
-    $rpc_addr = $config_hash_real['client_addr']
+    $http_addr = $config_hash_real['client_addr']
   } else {
-    $rpc_addr = $::ipaddress_lo
+    $http_addr = $::ipaddress_lo
   }
 
   if $services {

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -13,15 +13,15 @@ class consul::reload_service {
 
     # Make sure we don't try to connect to 0.0.0.0, use 127.0.0.1 instead
     # This can happen if the consul agent RPC port is bound to 0.0.0.0
-    if $::consul::rpc_addr == '0.0.0.0' {
-      $rpc_addr = '127.0.0.1'
+    if $::consul::http_addr == '0.0.0.0' {
+      $http_addr = '127.0.0.1'
     } else {
-      $rpc_addr = $::consul::rpc_addr
+      $http_addr = $::consul::http_addr
     }
 
     exec { 'reload consul service':
       path        => [$::consul::bin_dir,'/bin','/usr/bin'],
-      command     => "consul reload -rpc-addr=${rpc_addr}:${consul::rpc_port}",
+      command     => "consul reload -http-addr==${http_addr}:${consul::http_port}",
       refreshonly => true,
       tries       => 3,
     }

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -21,7 +21,7 @@ class consul::reload_service {
 
     exec { 'reload consul service':
       path        => [$::consul::bin_dir,'/bin','/usr/bin'],
-      command     => "consul reload -http-addr==${http_addr}:${consul::http_port}",
+      command     => "consul reload -http-addr=${http_addr}:${consul::http_port}",
       refreshonly => true,
       tries       => 3,
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -285,7 +285,7 @@ describe 'consul' do
           'server' => false,
           'ports' => {
             'http' => 1,
-            'rpc'  => '8300',
+            'https' => '8300',
           },
       },
       :config_hash => {
@@ -293,7 +293,7 @@ describe 'consul' do
           'server' => true,
           'ports' => {
             'http'  => -1,
-            'https' => 8500,
+            'https' => '8500',
           },
       }
     }}
@@ -302,7 +302,6 @@ describe 'consul' do
     it { should contain_file('consul config.json').with_content(/"server":true/) }
     it { should contain_file('consul config.json').with_content(/"http":-1/) }
     it { should contain_file('consul config.json').with_content(/"https":8500/) }
-    it { should contain_file('consul config.json').with_content(/"rpc":8300/) }
   end
 
   context 'When pretty config is true' do
@@ -399,7 +398,7 @@ describe 'consul' do
     }}
     it {
       should contain_exec('reload consul service').
-        with_command('consul reload -rpc-addr=127.0.0.1:8400')
+        with_command('consul reload -http-addr=127.0.0.1:8500')
     }
   end
 
@@ -410,16 +409,16 @@ describe 'consul' do
       },
       :config_hash => {
         'ports' => {
-          'rpc' => '9999'
+          'http' => '9999'
         },
         'addresses' => {
-          'rpc' => 'consul.example.com'
+          'http' => 'consul.example.com'
         }
       }
     }}
     it {
       should contain_exec('reload consul service').
-        with_command('consul reload -rpc-addr=consul.example.com:9999')
+        with_command('consul reload -http-addr=consul.example.com:9999')
     }
   end
 
@@ -434,7 +433,7 @@ describe 'consul' do
     }}
     it {
       should contain_exec('reload consul service').
-        with_command('consul reload -rpc-addr=192.168.34.56:8400')
+        with_command('consul reload -http-addr=192.168.34.56:8500')
     }
   end
 
@@ -521,30 +520,30 @@ describe 'consul' do
     it { should contain_class('consul').with_init_style('init') }
     it {
       should contain_file('/etc/init.d/consul').
-        with_content(/-rpc-addr=127.0.0.1:8400/)
+        with_content(/-http-addr=127.0.0.1:8500/)
     }
   end
 
-  context "When overriding default rpc port on init" do
+  context "When overriding default http port on init" do
     let (:params) {{
       :init_style => 'init',
       :config_hash => {
         'ports' => {
-          'rpc' => '9999'
+          'http' => '9999'
         },
         'addresses' => {
-          'rpc' => 'consul.example.com'
+          'http' => 'consul.example.com'
         }
       }
     }}
     it { should contain_class('consul').with_init_style('init') }
     it {
       should contain_file('/etc/init.d/consul').
-        with_content(/-rpc-addr=consul.example.com:9999/)
+        with_content(/-http-addr=consul.example.com:9999/)
     }
   end
 
-  context "When rpc_addr defaults to client_addr on init" do
+  context "When http_addr defaults to client_addr on init" do
     let (:params) {{
       :init_style => 'init',
       :config_hash => {
@@ -554,7 +553,7 @@ describe 'consul' do
     it { should contain_class('consul').with_init_style('init') }
     it {
       should contain_file('/etc/init.d/consul').
-        with_content(/-rpc-addr=192.168.34.56:8400/)
+        with_content(/-http-addr=192.168.34.56:8500/)
     }
   end
 
@@ -568,26 +567,26 @@ describe 'consul' do
     it { should contain_class('consul').with_init_style('debian') }
     it {
       should contain_file('/etc/init.d/consul').
-        with_content(/-rpc-addr=127.0.0.1:8400/)
+        with_content(/-http-addr=127.0.0.1:8500/)
     }
   end
 
-  context "When overriding default rpc port on debian" do
+  context "When overriding default http port on debian" do
     let (:params) {{
       :init_style => 'debian',
       :config_hash => {
         'ports' => {
-          'rpc' => '9999'
+          'http' => '9999'
         },
         'addresses' => {
-          'rpc' => 'consul.example.com'
+          'http' => 'consul.example.com'
         }
       }
     }}
     it { should contain_class('consul').with_init_style('debian') }
     it {
       should contain_file('/etc/init.d/consul').
-        with_content(/-rpc-addr=consul.example.com:9999/)
+        with_content(/-http-addr=consul.example.com:9999/)
     }
   end
 
@@ -601,26 +600,26 @@ describe 'consul' do
     it { should contain_class('consul').with_init_style('upstart') }
     it {
       should contain_file('/etc/init/consul.conf').
-        with_content(/-rpc-addr=127.0.0.1:8400/)
+        with_content(/-http-addr=127.0.0.1:8500/)
     }
   end
 
-  context "When overriding default rpc port on upstart" do
+  context "When overriding default http port on upstart" do
     let (:params) {{
       :init_style => 'upstart',
       :config_hash => {
         'ports' => {
-          'rpc' => '9999'
+          'http' => '9999'
         },
         'addresses' => {
-          'rpc' => 'consul.example.com'
+          'http' => 'consul.example.com'
         }
       }
     }}
     it { should contain_class('consul').with_init_style('upstart') }
     it {
       should contain_file('/etc/init/consul.conf').
-        with_content(/-rpc-addr=consul.example.com:9999/)
+        with_content(/-http-addr=consul.example.com:9999/)
     }
   end
 

--- a/templates/consul.debian.erb
+++ b/templates/consul.debian.erb
@@ -21,7 +21,7 @@ PIDFILE=/var/run/$NAME/$NAME.pid
 DAEMON_ARGS="agent -config-dir <%= scope.lookupvar('consul::config_dir') %> <%= scope.lookupvar('consul::extra_options') %>"
 USER=<%= scope.lookupvar('consul::user') %>
 SCRIPTNAME=/etc/init.d/$NAME
-RPC_ADDR=-rpc-addr=<%= scope.lookupvar('consul::rpc_addr') %>:<%= scope.lookupvar('consul::rpc_port') %>
+HTTP_ADDR=-http-addr=<%= scope.lookupvar('consul::http_addr') %>:<%= scope.lookupvar('consul::http_port') %>
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -66,7 +66,7 @@ do_start()
             sleep 1
             continue
         fi
-        if "$DAEMON" info ${RPC_ADDR} >/dev/null; then
+        if "$DAEMON" info ${HTTP_ADDR} >/dev/null; then
             return 0
         fi
     done
@@ -80,8 +80,8 @@ do_start()
 do_stop()
 {
     # If consul is not acting as a server, exit gracefully
-    if ("${DAEMON}" info ${RPC_ADDR} 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
-        "$DAEMON" leave ${RPC_ADDR}
+    if ("${DAEMON}" info ${HTTP_ADDR} 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
+        "$DAEMON" leave ${HTTP_ADDR}
     fi
     # Return
     #   0 if daemon has been stopped

--- a/templates/consul.init.erb
+++ b/templates/consul.init.erb
@@ -17,7 +17,7 @@ CONSUL=<%= scope.lookupvar('consul::bin_dir') %>/consul
 CONFIG=<%= scope.lookupvar('consul::config_dir') %>
 PID_FILE=/var/run/consul/consul.pid
 LOG_FILE=<%= scope.lookupvar('consul::log_file') %>
-RPC_ADDR=-rpc-addr=<%= scope.lookupvar('consul::rpc_addr') %>:<%= scope.lookupvar('consul::rpc_port') %>
+HTTP_ADDR=-http-addr=<%= scope.lookupvar('consul::http_addr') %>:<%= scope.lookupvar('consul::http_port') %>
 
 [ -e /etc/sysconfig/consul ] && . /etc/sysconfig/consul
 
@@ -70,7 +70,7 @@ stop() {
         # If consul is not acting as a server, exit gracefully
         # Use SIGINT to create a "leave" event, unless the user has explicitly
         # changed that behavior in the Consul config.
-        if ("${CONSUL}" info ${RPC_ADDR} 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
+        if ("${CONSUL}" info ${HTTP_ADDR} 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
             consul_pid=$(cat $PID_FILE)
             killproc $KILLPROC_OPT $CONSUL -INT
             retcode=$?
@@ -109,7 +109,7 @@ case "$1" in
         stop
         ;;
     status)
-        "$CONSUL" info ${RPC_ADDR}
+        "$CONSUL" info ${HTTP_ADDR}
         ;;
     restart)
         stop

--- a/templates/consul.upstart.erb
+++ b/templates/consul.upstart.erb
@@ -11,7 +11,7 @@ env DEFAULTS=/etc/default/consul
 env RUNDIR=/var/run/consul
 env PID_FILE=/var/run/consul/consul.pid
 env LOG_FILE=<%= scope.lookupvar('consul::log_file') %>
-env RPC_ADDR=-rpc-addr=<%= scope.lookupvar('consul::rpc_addr') %>:<%= scope.lookupvar('consul::rpc_port') %>
+env HTTP_ADDR=-http-addr=<%= scope.lookupvar('consul::http_addr') %>:<%= scope.lookupvar('consul::http_port') %>
 
 pre-start script
   [ -e $DEFAULTS ] && . $DEFAULTS
@@ -32,8 +32,8 @@ end script
 
 pre-stop script
     # Only leave the cluster if running as an agent
-    if ("${CONSUL}" info ${RPC_ADDR} 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
-        exec "$CONSUL" leave ${RPC_ADDR}
+    if ("${CONSUL}" info ${HTTP_ADDR} 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
+        exec "$CONSUL" leave ${HTTP_ADDR}
     fi
 end script
 


### PR DESCRIPTION
This addresses #331 

- RPC interface is deprecated - https://www.consul.io/docs/upgrade-specific.html#command-line-interface-rpc-deprecation
- Replace `-rpc-addr` with `-http-addr`

Marked as `[WIP]`, as still testing in staging infrastructure