### PR TITLE
Notify the service when package is updated

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -82,12 +82,14 @@ class consul::install {
     'package': {
       package { $::consul::package_name:
         ensure => $::consul::package_ensure,
+        notify => $::consul::notify_service
       }
 
       if $::consul::ui_dir {
         package { $::consul::ui_package_name:
           ensure  => $::consul::ui_package_ensure,
-          require => Package[$::consul::package_name]
+          require => Package[$::consul::package_name],
+          notify  => $::consul::notify_service
         }
       }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -75,7 +75,7 @@ describe 'consul' do
     let(:params) {{
       :install_method => 'package'
     }}
-    it { should contain_package('consul').with(:ensure => 'latest') }
+    it { should contain_package('consul').with(:ensure => 'latest').that_notifies('Class[consul::run_service]') }
   end
 
   context 'When requesting to install via a custom package and version' do


### PR DESCRIPTION
Currently, when you install consul via a package that you've built, the service doesn't get notified. This means the old consul version continues to run.

