### PR TITLE
support other unspecified RedHat variants

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,17 +61,25 @@ class consul::params {
     } else {
       $init_style = 'systemd'
     }
-  } elsif $::operatingsystem =~ /Scientific|CentOS|RedHat|OracleLinux/ {
-    if versioncmp($::operatingsystemrelease, '7.0') < 0 {
-      $init_style = 'redhat'
-    } else {
-      $init_style  = 'systemd'
-    }
-  } elsif $::operatingsystem == 'Fedora' {
-    if versioncmp($::operatingsystemrelease, '12') < 0 {
-      $init_style = 'init'
-    } else {
-      $init_style = 'systemd'
+  } elsif $::osfamily == 'RedHat' {
+    case $::operatingsystem {
+      'Fedora': {
+        if versioncmp($::operatingsystemrelease, '12') < 0 {
+          $init_style = 'init'
+        } else {
+          $init_style = 'systemd'
+        }
+      }
+      'Amazon': {
+          $init_style = 'redhat'
+      }
+      default: {
+        if versioncmp($::operatingsystemrelease, '7.0') < 0 {
+          $init_style = 'redhat'
+        } else {
+          $init_style  = 'systemd'
+        }
+      }
     }
   } elsif $::operatingsystem == 'Debian' {
     if versioncmp($::operatingsystemrelease, '8.0') < 0 {
@@ -91,16 +99,8 @@ class consul::params {
     }
   } elsif $::operatingsystem == 'Darwin' {
     $init_style = 'launchd'
-  } elsif $::operatingsystem == 'Amazon' {
-    $init_style = 'redhat'
   } elsif $::operatingsystem == 'FreeBSD' {
     $init_style = 'freebsd'
-  } elsif $::osfamily == 'RedHat' {
-    if versioncmp($::operatingsystemrelease, '7.0') < 0 {
-      $init_style = 'redhat'
-    } else {
-      $init_style  = 'systemd'
-    }
   } else {
     fail('Cannot determine init_style, unsupported OS')
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -95,6 +95,12 @@ class consul::params {
     $init_style = 'redhat'
   } elsif $::operatingsystem == 'FreeBSD' {
     $init_style = 'freebsd'
+  } elsif $::osfamily == 'RedHat' {
+    if versioncmp($::operatingsystemrelease, '7.0') < 0 {
+      $init_style = 'redhat'
+    } else {
+      $init_style  = 'systemd'
+    }
   } else {
     fail('Cannot determine init_style, unsupported OS')
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -625,6 +625,7 @@ describe 'consul' do
 
   context "On a redhat 6 based OS" do
     let(:facts) {{
+      :osfamily => 'RedHat',
       :operatingsystem => 'CentOS',
       :operatingsystemrelease => '6.5'
     }}
@@ -644,6 +645,7 @@ describe 'consul' do
 
   context "On an Amazon based OS" do
     let(:facts) {{
+      :osfamily => 'RedHat',
       :operatingsystem => 'Amazon',
       :operatingsystemrelease => '3.10.34-37.137.amzn1.x86_64'
     }}
@@ -654,6 +656,7 @@ describe 'consul' do
 
   context "On a redhat 7 based OS" do
     let(:facts) {{
+      :osfamily => 'RedHat',
       :operatingsystem => 'CentOS',
       :operatingsystemrelease => '7.0'
     }}
@@ -664,6 +667,7 @@ describe 'consul' do
 
   context "On a fedora 20 based OS" do
     let(:facts) {{
+      :osfamily => 'RedHat',
       :operatingsystem => 'Fedora',
       :operatingsystemrelease => '20'
     }}


### PR DESCRIPTION
This allows the module to be used on other RedHat derivatives that are not specifically specified as supported. I have a proprietary variant, that I would like to use this module with, without specifically listing it as supported. 
