### PR TITLE
Support "Near" parameter in prepared queries

### DIFF
--- a/lib/puppet/provider/consul_prepared_query/default.rb
+++ b/lib/puppet/provider/consul_prepared_query/default.rb
@@ -149,6 +149,7 @@ Puppet::Type.type(:consul_prepared_query).provide(
     name = @resource[:name]
     token = @resource[:token]
     service_name = @resource[:service_name]
+    service_near = @resource[:service_near]
     service_failover_n = @resource[:service_failover_n]
     service_failover_dcs = @resource[:service_failover_dcs]
     service_only_passing = @resource[:service_only_passing]
@@ -167,6 +168,7 @@ Puppet::Type.type(:consul_prepared_query).provide(
       "Token"   => "#{token}",
       "Service" => {
         "Service"     => "#{service_name}",
+        "Near"        => "#{service_near}",
         "Failover"    => {
           "NearestN"    => service_failover_n,
           "Datacenters" => service_failover_dcs,

--- a/lib/puppet/type/consul_prepared_query.rb
+++ b/lib/puppet/type/consul_prepared_query.rb
@@ -53,6 +53,14 @@ Puppet::Type.newtype(:consul_prepared_query) do
     end
   end
 
+  newparam(:service_near) do
+    desc 'Resurn results in ascending order of estimated RTT from given node name, or _agent special value'
+    defaultto ''
+    validate do |value|
+      raise ArgumentError, "Near parameter must be a string" if not value.is_a?(String)
+    end
+  end
+
   newparam(:service_only_passing) do
     desc 'Only return services in the passing state'
     defaultto false


### PR DESCRIPTION
What it says on the tin; this just adds support for setting the Near parameter when creating prepared queries. By default this does nothing (empty string), but the _agent special value seems particularly useful to me.