### PR TITLE
added docker support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@ Kenny Gatdula <kennygatdula@gmail.com>
 Simon Croome <simon@croome.org>
 Dan Tehranian <tehranian@gmail.com>
 Vik Bhatti <vik@vikbhatti.com>
+Justin King <justin.dynamicd@gmail.com>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ new versions of consul. Pin to the version that works for your setup!
 
 * Installs the consul daemon (via url or package)
   * If installing from zip, you *must* ensure the unzip utility is available.
+  * If installing from docker, you *must* ensure puppetlabs-docker_platform module is available.
 * Optionally installs a user to run it under
 * Installs a configuration file (/etc/consul/config.json)
 * Manages the consul service via upstart, sysv, or systemd

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -84,10 +84,10 @@ define consul::check(
   consul_validate_checks($check_hash[check])
 
   $escaped_id = regsubst($id,'\/','_','G')
-  
+
   file { "check_${escaped_id} with consul accounts" :
-    path    => "${consul::config_dir}/check_${escaped_id}.json",
     ensure  => $ensure,
+    path    => "${consul::config_dir}/check_${escaped_id}.json",
     owner   => $::consul::user_real,
     group   => $::consul::group_real,
     mode    => $::consul::config_mode,

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -85,26 +85,15 @@ define consul::check(
 
   $escaped_id = regsubst($id,'\/','_','G')
   
-  if $::consul::selected_install_method != 'docker' {
-    file { "check_${escaped_id} with consul accounts" :
-      path    => "${consul::config_dir}/check_${escaped_id}.json",
-      ensure  => $ensure,
-      owner   => $::consul::user,
-      group   => $::consul::group,
-      mode    => $::consul::config_mode,
-      content => consul_sorted_json($check_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-      notify  => Class['consul::reload_service'],
-      require => File[$::consul::config_dir],
-    }
+  file { "check_${escaped_id} with consul accounts" :
+    path    => "${consul::config_dir}/check_${escaped_id}.json",
+    ensure  => $ensure,
+    owner   => $::consul::user,
+    group   => $::consul::group,
+    mode    => $::consul::config_mode,
+    content => consul_sorted_json($check_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+    notify  => Class['consul::reload_service'],
+    require => File[$::consul::config_dir],
   }
-  else {
-    file { "check_${escaped_id} without consul accounts" :
-      path    => "${consul::config_dir}/check_${escaped_id}.json",
-      ensure  => $ensure,
-      mode    => $::consul::config_mode,
-      content => consul_sorted_json($check_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-      notify  => Class['consul::reload_service'],
-      require => File[$::consul::config_dir],
-    }
-  }
+
 }

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -84,16 +84,13 @@ define consul::check(
   consul_validate_checks($check_hash[check])
 
   $escaped_id = regsubst($id,'\/','_','G')
-
-  file { "check_${escaped_id} with consul accounts" :
+  File[$::consul::config_dir]
+  -> file { "${consul::config_dir}/check_${escaped_id}.json" :
     ensure  => $ensure,
-    path    => "${consul::config_dir}/check_${escaped_id}.json",
     owner   => $::consul::user_real,
     group   => $::consul::group_real,
     mode    => $::consul::config_mode,
     content => consul_sorted_json($check_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-    notify  => Class['consul::reload_service'],
-    require => File[$::consul::config_dir],
-  }
+  } ~> Class['consul::reload_service']
 
 }

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -84,23 +84,27 @@ define consul::check(
   consul_validate_checks($check_hash[check])
 
   $escaped_id = regsubst($id,'\/','_','G')
-  File[$::consul::config_dir]
-  -> file { "check_${escaped_id} with consul accounts":
-    path    => "${consul::config_dir}/check_${escaped_id}.json",
-    ensure  => $ensure,
-    owner   => $::consul::user,
-    group   => $::consul::group,
-    mode    => $::consul::config_mode,
-    content => consul_sorted_json($check_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-    notify  => Class['consul::reload_service'],
-    unless  => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+  
+  if $::consul::selected_install_method != 'docker' {
+    file { "check_${escaped_id} with consul accounts" :
+      path    => "${consul::config_dir}/check_${escaped_id}.json",
+      ensure  => $ensure,
+      owner   => $::consul::user,
+      group   => $::consul::group,
+      mode    => $::consul::config_mode,
+      content => consul_sorted_json($check_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+      notify  => Class['consul::reload_service'],
+      require => File[$::consul::config_dir],
+    }
   }
-  -> file { "check_${escaped_id} without consul accounts":
-    path    => "${consul::config_dir}/check_${escaped_id}.json",
-    ensure  => $ensure,
-    mode    => $::consul::config_mode,
-    content => consul_sorted_json($check_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-    notify  => Class['consul::reload_service'],
-    onlyif => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+  else {
+    file { "check_${escaped_id} without consul accounts" :
+      path    => "${consul::config_dir}/check_${escaped_id}.json",
+      ensure  => $ensure,
+      mode    => $::consul::config_mode,
+      content => consul_sorted_json($check_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+      notify  => Class['consul::reload_service'],
+      require => File[$::consul::config_dir],
+    }
   }
 }

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -88,8 +88,8 @@ define consul::check(
   file { "check_${escaped_id} with consul accounts" :
     path    => "${consul::config_dir}/check_${escaped_id}.json",
     ensure  => $ensure,
-    owner   => $::consul::user,
-    group   => $::consul::group,
+    owner   => $::consul::user_real,
+    group   => $::consul::group_real,
     mode    => $::consul::config_mode,
     content => consul_sorted_json($check_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
     notify  => Class['consul::reload_service'],

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -85,7 +85,7 @@ define consul::check(
 
   $escaped_id = regsubst($id,'\/','_','G')
   File[$::consul::config_dir]
-  -> file { "${consul::config_dir}/check_${escaped_id}.json" :
+  -> file { "${consul::config_dir}/check_${escaped_id}.json":
     ensure  => $ensure,
     owner   => $::consul::user_real,
     group   => $::consul::group_real,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,9 +15,9 @@ class consul::config(
   $purge = true,
 ) {
 
-  if ($::consul::init_style != 'unmanaged') {
+  if ($::consul::init_style_real != 'unmanaged') {
 
-    case $::consul::init_style {
+    case $::consul::init_style_real {
       'upstart': {
         file { '/etc/init/consul.conf':
           mode    => '0444',
@@ -93,7 +93,7 @@ class consul::config(
         }
       }
       default: {
-        fail("I don't know how to create an init script for style ${consul::init_style}")
+        fail("I don't know how to create an init script for style ${consul::init_style_real}")
       }
     }
   }
@@ -101,8 +101,8 @@ class consul::config(
   file { 'consul config.json' :
     ensure  => present,
     path    => "${consul::config_dir}/config.json",
-    owner   => $::consul::user,
-    group   => $::consul::group,
+    owner   => $::consul::user_real,
+    group   => $::consul::group_real,
     mode    => $::consul::config_mode,
     content => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
     require => File[$::consul::config_dir],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -105,6 +105,7 @@ class consul::config(
       mode    => $::consul::config_mode,
       content => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
       require => File[$::consul::config_dir],
+      notify  => Class['consul::reload_service'],
     }
 
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,6 @@ class consul::config(
   $config_hash,
   $purge = true,
   $init_style,
-  $selected_install_method,
 ) {
 
   if $init_style != 'unmanaged' {
@@ -100,7 +99,7 @@ class consul::config(
     }
   }
   
-  if $selected_install_method == 'docker' {
+  if $::consul::selected_install_method == 'docker' {
     file { 'consul config.json' :
       ensure  => present,
       path    => "${consul::config_dir}/config.json",
@@ -122,7 +121,7 @@ class consul::config(
     }
   }
 
-  if $selected_install_method == 'docker' {
+  if $::consul::selected_install_method == 'docker' {
     $docker_ensure = 'present'
   }
   else {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -101,36 +101,36 @@ class consul::config(
   }
   
   if $selected_install_method == 'docker' {
-    file { $::consul::config_dir:
-      ensure  => 'directory',
-      purge   => $purge,
-      recurse => $purge,
-    }
-
-    -> file { 'consul config.json':
+    file { 'consul config.json' :
       ensure  => present,
       path    => "${consul::config_dir}/config.json",
       mode    => $::consul::config_mode,
       content => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+      require => File[$::consul::config_dir],
     }
 
   }
   else {
-    file { $::consul::config_dir:
-      ensure  => 'directory',
-      owner   => $::consul::user,
-      group   => $::consul::group,
-      purge   => $purge,
-      recurse => $purge,
-    }
-
-    -> file { 'consul config.json':
+    file { 'consul config.json' :
       ensure  => present,
       path    => "${consul::config_dir}/config.json",
       owner   => $::consul::user,
       group   => $::consul::group,
       mode    => $::consul::config_mode,
       content => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+      require => File[$::consul::config_dir],
     }
   }
+
+  if $selected_install_method == 'docker' {
+    $docker_ensure = 'present'
+  }
+  else {
+    $docker_ensure = 'absent'
+  }
+  file { 'docker_used':
+      ensure  => $docker_ensure,
+      path    => "${consul::config_dir}/docker_used",
+      content => '# This file was created by puppet-consul to track if docker is being used to manage services',
+    }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,12 +13,11 @@
 class consul::config(
   $config_hash,
   $purge = true,
-  $init_style,
 ) {
 
-  if $init_style != 'unmanaged' {
+  if ($::consul::init_style != 'unmanaged') and ($::consul::selected_install_method != 'docker') {
 
-    case $init_style {
+    case $::consul::init_style {
       'upstart': {
         file { '/etc/init/consul.conf':
           mode    => '0444',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -100,8 +100,8 @@ class consul::config(
 
   file { $::consul::config_dir:
     ensure  => 'directory',
-    owner   => $::consul::user,
-    group   => $::consul::group,
+    owner   => $::consul::user_real,
+    group   => $::consul::group_real,
     purge   => $purge,
     recurse => $purge,
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,7 +15,7 @@ class consul::config(
   $purge = true,
 ) {
 
-  if ($::consul::init_style != 'unmanaged') and ($::consul::selected_install_method != 'docker') {
+  if ($::consul::init_style != 'unmanaged') {
 
     case $::consul::init_style {
       'upstart': {
@@ -97,39 +97,15 @@ class consul::config(
       }
     }
   }
-  
-  if $::consul::selected_install_method == 'docker' {
-    file { 'consul config.json' :
-      ensure  => present,
-      path    => "${consul::config_dir}/config.json",
-      mode    => $::consul::config_mode,
-      content => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-      require => File[$::consul::config_dir],
-      notify  => Class['consul::reload_service'],
-    }
 
-  }
-  else {
-    file { 'consul config.json' :
-      ensure  => present,
-      path    => "${consul::config_dir}/config.json",
-      owner   => $::consul::user,
-      group   => $::consul::group,
-      mode    => $::consul::config_mode,
-      content => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-      require => File[$::consul::config_dir],
-    }
+  file { 'consul config.json' :
+    ensure  => present,
+    path    => "${consul::config_dir}/config.json",
+    owner   => $::consul::user,
+    group   => $::consul::group,
+    mode    => $::consul::config_mode,
+    content => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+    require => File[$::consul::config_dir],
   }
 
-  if $::consul::selected_install_method == 'docker' {
-    $docker_ensure = 'present'
-  }
-  else {
-    $docker_ensure = 'absent'
-  }
-  file { 'docker_used':
-      ensure  => $docker_ensure,
-      path    => "${consul::config_dir}/docker_used",
-      content => '# This file was created by puppet-consul to track if docker is being used to manage services',
-    }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -98,7 +98,14 @@ class consul::config(
     }
   }
 
-  file { 'consul config.json' :
+  file { $::consul::config_dir:
+    ensure  => 'directory',
+    owner   => $::consul::user,
+    group   => $::consul::group,
+    purge   => $purge,
+    recurse => $purge,
+  }
+  -> file { 'consul config.json' :
     ensure  => present,
     path    => "${consul::config_dir}/config.json",
     owner   => $::consul::user_real,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -105,7 +105,7 @@ class consul::config(
     purge   => $purge,
     recurse => $purge,
   }
-  -> file { 'consul config.json' :
+  -> file { 'consul config.json':
     ensure  => present,
     path    => "${consul::config_dir}/config.json",
     owner   => $::consul::user_real,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -212,6 +212,19 @@ class consul (
 
   $config_hash_real = deep_merge($config_defaults, $config_hash)
 
+  if $install_method == 'docker' {
+    $user_real = undef
+    $group_real = undef
+    $init_style_real = 'unmanaged'
+    $manage_service_real = false
+  }
+  else {
+    $user_real = $user
+    $group_real = $group
+    $init_style_real = $init_style
+    $manage_service_real = $manage_service
+  }
+
   if $config_hash_real['data_dir'] {
     $data_dir = $config_hash_real['data_dir']
   } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -277,7 +277,7 @@ class consul (
   }
 
   anchor {'consul_first': }
-  -> class { 'consul::install': 
+  -> class { 'consul::install':
     purge => $purge_config_dir,
   }
   -> class { 'consul::config':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,8 +58,7 @@
 #   This is ignored when install_method == 'docker'
 #
 # [*install_method*]
-#   Valid strings: `auto`    - use docker if available, fallback to url if not
-#                  `docker`  - install via docker container
+#   Valid strings: `docker`  - install via docker container
 #                  `package` - install via system package
 #                  `url`     - download and extract from a url. Defaults to `url`.
 #                  `none`    - disable install.
@@ -257,18 +256,6 @@ class consul (
 
   if $acls {
     create_resources(consul_acl, $acls)
-  }
-
-  if $install_method == 'auto' {
-    if $facts['networking']['interfaces']['docker0'] {
-      $selected_install_method = 'docker'
-    }
-    else {
-      $selected_install_method = 'url'
-    }
-  }
-  else {
-    $selected_install_method = $install_method
   }
 
   $notify_service = $restart_on_change ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -277,11 +277,13 @@ class consul (
   }
 
   anchor {'consul_first': }
-  -> class { 'consul::install': }
+  -> class { 'consul::install': 
+    purge => $purge_config_dir,
+  }
   -> class { 'consul::config':
-    config_hash             => $config_hash_real,
-    purge                   => $purge_config_dir,
-    notify                  => $notify_service,
+    config_hash => $config_hash_real,
+    purge       => $purge_config_dir,
+    notify      => $notify_service,
   }
   -> class { 'consul::run_service': }
   -> class { 'consul::reload_service': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,9 @@
 # [*config_mode*]
 #   Use this to set the JSON config file mode for consul.
 #
+# [*docker_image*]
+#   Only valid when the install_method == docker. Defaults to `consul`.
+#
 # [*download_extension*]
 #   The extension of the archive file containing the consul binary to download.
 #
@@ -54,7 +57,9 @@
 #   managing init system files for the consul service entirely.
 #
 # [*install_method*]
-#   Valid strings: `package` - install via system package
+#   Valid strings: `auto`    - use docker if available, fallback to url if not
+#                  `docker`  - install via docker container
+#                  `package` - install via system package
 #                  `url`     - download and extract from a url. Defaults to `url`.
 #                  `none`    - disable install.
 #
@@ -151,6 +156,7 @@ class consul (
   $config_dir            = $::consul::params::config_dir,
   $config_hash           = $::consul::params::config_hash,
   $config_mode           = $::consul::params::config_mode,
+  $docker_image          = $::consul::params::docker_image,
   $download_extension    = $::consul::params::download_extension,
   $download_url          = $::consul::params::download_url,
   $download_url_base     = $::consul::params::download_url_base,
@@ -250,6 +256,18 @@ class consul (
 
   if $acls {
     create_resources(consul_acl, $acls)
+  }
+
+  if $install_method == 'auto' {
+    if $facts['networking']['interfaces']['docker0'] {
+      $selected_install_method = 'docker'
+    }
+    else {
+      $selected_install_method = 'url'
+    }
+  }
+  else {
+    $selected_install_method = $install_method
   }
 
   $notify_service = $restart_on_change ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -264,7 +264,7 @@ class consul (
       $selected_install_method = 'docker'
     }
     else {
-      $selected_install_method = 'package'
+      $selected_install_method = 'url'
     }
   }
   else {
@@ -281,14 +281,11 @@ class consul (
   }
 
   anchor {'consul_first': }
-  -> class { 'consul::install':
-    selected_install_method => $selected_install_method,
-  }
+  -> class { 'consul::install': }
   -> class { 'consul::config':
     config_hash             => $config_hash_real,
     purge                   => $purge_config_dir,
     init_style              => $init_style,
-    selected_install_method => $selected_install_method,
     notify                  => $notify_service,
   }
   -> class { 'consul::run_service': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -271,10 +271,6 @@ class consul (
     $selected_install_method = $install_method
   }
 
-  if $selected_install_method == 'docker' {
-    $init_style = 'unmanaged'
-  }
-
   $notify_service = $restart_on_change ? {
     true    => Class['consul::run_service'],
     default => undef,
@@ -285,7 +281,6 @@ class consul (
   -> class { 'consul::config':
     config_hash             => $config_hash_real,
     purge                   => $purge_config_dir,
-    init_style              => $init_style,
     notify                  => $notify_service,
   }
   -> class { 'consul::run_service': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -277,9 +277,7 @@ class consul (
   }
 
   anchor {'consul_first': }
-  -> class { 'consul::install':
-    purge => $purge_config_dir,
-  }
+  -> class { 'consul::install': }
   -> class { 'consul::config':
     config_hash => $config_hash_real,
     purge       => $purge_config_dir,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -216,13 +216,11 @@ class consul (
     $user_real = undef
     $group_real = undef
     $init_style_real = 'unmanaged'
-    $manage_service_real = false
   }
   else {
     $user_real = $user
     $group_real = $group
     $init_style_real = $init_style
-    $manage_service_real = $manage_service
   }
 
   if $config_hash_real['data_dir'] {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,8 +4,8 @@
 #
 class consul::install {
 
-  if ($::consul::data_dir) and ($::consul::install_method != 'docker') {
-    file { $::consul::data_dir :
+  if $::consul::data_dir {
+    file { $::consul::data_dir:
       ensure => 'directory',
       owner  => $::consul::user_real,
       group  => $::consul::group_real,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,11 +2,9 @@
 #
 # Installs consul based on the parameters from init
 #
-class consul::install (
-  $selected_install_method,
-) {
+class consul::install {
 
-  if ($::consul::data_dir) and ($selected_install_method != 'docker') {
+  if ($::consul::data_dir) and ($::consul::selected_install_method != 'docker') {
     file { $::consul::data_dir:
       ensure => 'directory',
       owner  => $::consul::user,
@@ -15,7 +13,7 @@ class consul::install (
     }
   }
 
-  if $selected_install_method == 'docker' {
+  if $::consul::selected_install_method == 'docker' {
     file { $::consul::config_dir:
       ensure  => 'directory',
       purge   => $purge,
@@ -32,7 +30,7 @@ class consul::install (
     }
   }
 
-  case $selected_install_method {
+  case $::consul::selected_install_method {
     'docker': {
       if $::consul::http_addr == '0.0.0.0' {
         $http_addr = '127.0.0.1'
@@ -155,18 +153,18 @@ class consul::install (
     }
   }
 
-  if ($::consul::manage_user) and ($selected_install_method != 'docker' ) {
+  if ($::consul::manage_user) and ($::consul::selected_install_method != 'docker' ) {
     user { $::consul::user:
       ensure => 'present',
       system => true,
       groups => $::consul::extra_groups,
     }
 
-    if ($::consul::manage_group) and ($selected_install_method != 'docker' ) {
+    if ($::consul::manage_group) and ($::consul::selected_install_method != 'docker' ) {
       Group[$::consul::group] -> User[$::consul::user]
     }
   }
-  if ($::consul::manage_group) and ($selected_install_method != 'docker' ) {
+  if ($::consul::manage_group) and ($::consul::selected_install_method != 'docker' ) {
     group { $::consul::group:
       ensure => 'present',
       system => true,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,7 +2,9 @@
 #
 # Installs consul based on the parameters from init
 #
-class consul::install {
+class consul::install (
+  $purge = true,
+) {
 
   if ($::consul::data_dir) and ($::consul::install_method != 'docker') {
     file { $::consul::data_dir :

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,9 +15,14 @@ class consul::install {
 
   case $selected_install_method {
     'docker': {
+
+      $retry_join = pick($::consul::config_hash[retry_join], '/opt/consul')
+      $server_mode = pick($::consul::config_hash[server], false)
+      $client_addr = pick($::consul::config_hash[client_addr], $consul::http_addr)
+
       if $server_mode {
         $env = [ '\'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}\'', '\'CONSUL_ALLOW_PRIVILEGED_PORTS=\'']
-        $command = "agent -server -bind=${::ipaddress} -retry-join=${retry_join} -dns-port=53 -client=${::ipaddress} -bootstrap-expect=3"
+        $command = "agent -server -bind=${::ipaddress} -retry-join=${retry_join} -dns-port=53 -client=${client_addr} -bootstrap-expect=3"
       }
       else {
         $env = [ '\'CONSUL_LOCAL_CONFIG={"leave_on_terminate": true}\'' ]

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,9 +2,7 @@
 #
 # Installs consul based on the parameters from init
 #
-class consul::install (
-  $purge = true,
-) {
+class consul::install {
 
   if ($::consul::data_dir) and ($::consul::install_method != 'docker') {
     file { $::consul::data_dir :
@@ -13,14 +11,6 @@ class consul::install (
       group  => $::consul::group_real,
       mode   => '0755',
     }
-  }
-
-  file { $::consul::config_dir :
-    ensure  => 'directory',
-    owner   => $::consul::user_real,
-    group   => $::consul::group_real,
-    purge   => $purge,
-    recurse => $purge,
   }
 
   case $::consul::install_method {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,11 +41,11 @@ class consul::install {
       
       if $server_mode {
         $env = [ '\'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}\'', '\'CONSUL_ALLOW_PRIVILEGED_PORTS=\'']
-        $command = "agent -server -http-addr=${http_addr}:${consul::http_port}"
+        $command = "agent -server -client=${http_addr}:${consul::http_port}"
       }
       else {
         $env = [ '\'CONSUL_LOCAL_CONFIG={"leave_on_terminate": true}\'' ]
-        $command = "agent -http-addr=${http_addr}:${consul::http_port}"
+        $command = "agent -client=${http_addr}:${consul::http_port}"
       }
 
       # Docker Install

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,16 +7,16 @@ class consul::install {
   if ($::consul::data_dir) and ($::consul::install_method != 'docker') {
     file { $::consul::data_dir :
       ensure => 'directory',
-      owner  => $::consul::user,
-      group  => $::consul::group,
+      owner  => $::consul::user_real,
+      group  => $::consul::group_real,
       mode   => '0755',
     }
   }
 
   file { $::consul::config_dir :
     ensure  => 'directory',
-    owner   => $::consul::user,
-    group   => $::consul::group,
+    owner   => $::consul::user_real,
+    group   => $::consul::group_real,
     purge   => $purge,
     recurse => $purge,
   }
@@ -107,7 +107,7 @@ class consul::install {
       }
 
       if $::consul::manage_user {
-        User[$::consul::user] -> Package[$::consul::package_name]
+        User[$::consul::user_real] -> Package[$::consul::package_name]
       }
 
       if $::consul::data_dir {
@@ -121,18 +121,18 @@ class consul::install {
   }
 
   if ($::consul::manage_user) and ($::consul::install_method != 'docker' ) {
-    user { $::consul::user:
+    user { $::consul::user_real:
       ensure => 'present',
       system => true,
       groups => $::consul::extra_groups,
     }
 
     if ($::consul::manage_group) and ($::consul::install_method != 'docker' ) {
-      Group[$::consul::group] -> User[$::consul::user]
+      Group[$::consul::group_real] -> User[$::consul::user_real]
     }
   }
   if ($::consul::manage_group) and ($::consul::install_method != 'docker' ) {
-    group { $::consul::group:
+    group { $::consul::group_real:
       ensure => 'present',
       system => true,
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -32,20 +32,15 @@ class consul::install {
 
   case $::consul::selected_install_method {
     'docker': {
-      if $::consul::http_addr == '0.0.0.0' {
-        $http_addr = '127.0.0.1'
-      } else {
-        $http_addr = $::consul::http_addr
-      }
       $server_mode = pick($::consul::config_hash[server], false)
       
       if $server_mode {
         $env = [ '\'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}\'', '\'CONSUL_ALLOW_PRIVILEGED_PORTS=\'']
-        $command = "agent -server -client=${http_addr}:${consul::http_port}"
+        $command = "agent -server"
       }
       else {
         $env = [ '\'CONSUL_LOCAL_CONFIG={"leave_on_terminate": true}\'' ]
-        $command = "agent -client=${http_addr}:${consul::http_port}"
+        $command = "agent"
       }
 
       # Docker Install

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,6 +53,8 @@ class consul::params {
     }
   }
 
+  $os = downcase($::kernel)
+
   if $::operatingsystem == 'Ubuntu' {
     if versioncmp($::operatingsystemrelease, '8.04') < 1 {
       $init_style = 'debian'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class consul::params {
   $config_dir            = '/etc/consul'
   $config_hash           = {}
   $config_mode           = '0660'
+  $docker_image          = 'consul'
   $download_extension    = 'zip'
   $download_url          = undef
   $download_url_base     = 'https://releases.hashicorp.com/consul/'
@@ -19,7 +20,7 @@ class consul::params {
   $extra_options         = ''
   $group                 = 'consul'
   $log_file              = '/var/log/consul'
-  $install_method        = 'url'
+  $install_method        = 'auto'
   $join_wan              = false
   $manage_group          = true
   $manage_service        = true
@@ -40,7 +41,7 @@ class consul::params {
   $ui_package_ensure     = 'latest'
   $ui_package_name       = 'consul_ui'
   $user                  = 'consul'
-  $version               = '0.7.4'
+  $version               = '0.9.0'
   $watches               = {}
 
   case $::architecture {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class consul::params {
   $extra_options         = ''
   $group                 = 'consul'
   $log_file              = '/var/log/consul'
-  $install_method        = 'auto'
+  $install_method        = 'package'
   $join_wan              = false
   $manage_group          = true
   $manage_service        = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class consul::params {
   $ui_package_ensure     = 'latest'
   $ui_package_name       = 'consul_ui'
   $user                  = 'consul'
-  $version               = '0.9.0'
+  $version               = '0.7.4'
   $watches               = {}
 
   case $::architecture {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,10 +18,12 @@ class consul::params {
   $download_url_base     = 'https://releases.hashicorp.com/consul/'
   $extra_groups          = []
   $extra_options         = ''
+  $group                 = 'consul'
   $log_file              = '/var/log/consul'
-  $install_method        = 'package'
+  $install_method        = 'url'
   $join_wan              = false
   $manage_group          = true
+  $manage_service        = true
   $manage_user           = true
   $package_ensure        = 'latest'
   $package_name          = 'consul'
@@ -38,6 +40,7 @@ class consul::params {
   $ui_download_url_base  = 'https://releases.hashicorp.com/consul/'
   $ui_package_ensure     = 'latest'
   $ui_package_name       = 'consul_ui'
+  $user                  = 'consul'
   $version               = '0.9.0'
   $watches               = {}
 
@@ -50,23 +53,7 @@ class consul::params {
     }
   }
 
-  if $::consul::install_method == 'docker' {
-    $user = undef
-    $group = undef
-    $manage_service = false
-  }
-  else {
-    $user = 'consul'
-    $group = 'consul'
-    $manage_service = true
-  }
-
-  $os = downcase($::kernel)
-
-  if $::consul::install_method == 'docker' {
-    $init_style = 'unmanaged'
-  }
-  elsif $::operatingsystem == 'Ubuntu' {
+  if $::operatingsystem == 'Ubuntu' {
     if versioncmp($::operatingsystemrelease, '8.04') < 1 {
       $init_style = 'debian'
     } elsif versioncmp($::operatingsystemrelease, '15.04') < 0 {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,12 +18,10 @@ class consul::params {
   $download_url_base     = 'https://releases.hashicorp.com/consul/'
   $extra_groups          = []
   $extra_options         = ''
-  $group                 = 'consul'
   $log_file              = '/var/log/consul'
   $install_method        = 'package'
   $join_wan              = false
   $manage_group          = true
-  $manage_service        = true
   $manage_user           = true
   $package_ensure        = 'latest'
   $package_name          = 'consul'
@@ -40,7 +38,6 @@ class consul::params {
   $ui_download_url_base  = 'https://releases.hashicorp.com/consul/'
   $ui_package_ensure     = 'latest'
   $ui_package_name       = 'consul_ui'
-  $user                  = 'consul'
   $version               = '0.9.0'
   $watches               = {}
 
@@ -53,9 +50,23 @@ class consul::params {
     }
   }
 
+  if $::consul::install_method == 'docker' {
+    $user = undef
+    $group = undef
+    $manage_service = false
+  }
+  else {
+    $user = 'consul'
+    $group = 'consul'
+    $manage_service = true
+  }
+
   $os = downcase($::kernel)
 
-  if $::operatingsystem == 'Ubuntu' {
+  if $::consul::install_method == 'docker' {
+    $init_style = 'unmanaged'
+  }
+  elsif $::operatingsystem == 'Ubuntu' {
     if versioncmp($::operatingsystemrelease, '8.04') < 1 {
       $init_style = 'debian'
     } elsif versioncmp($::operatingsystemrelease, '15.04') < 0 {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class consul::params {
   $config_defaults       = {}
   $config_dir            = '/etc/consul'
   $config_hash           = {}
-  $config_mode           = '0660'
+  $config_mode           = '0664'
   $docker_image          = 'consul'
   $download_extension    = 'zip'
   $download_url          = undef

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -24,7 +24,17 @@ class consul::reload_service {
       command     => "consul reload -http-addr=${http_addr}:${consul::http_port}",
       refreshonly => true,
       tries       => 3,
+      unless      => "/usr/bin/test -e ${consul::config_dir}/docker_used",
     }
+
+    exec { 'reload consul service docker':
+      path        => [$::consul::bin_dir,'/bin','/usr/bin'],
+      command     => "docker exec -t consul consul reload -http-addr=${http_addr}:${consul::http_port}",
+      refreshonly => true,
+      tries       => 3,
+      onlyif      => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+    }
+
   }
 
 }

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -29,7 +29,7 @@ class consul::reload_service {
 
     exec { 'reload consul service docker':
       path        => [$::consul::bin_dir,'/bin','/usr/bin'],
-      command     => "docker exec -t consul consul reload -http-addr=${http_addr}:${consul::http_port}",
+      command     => "docker restart consul",
       refreshonly => true,
       tries       => 3,
       onlyif      => "/usr/bin/test -e ${consul::config_dir}/docker_used",

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -19,22 +19,16 @@ class consul::reload_service {
       $http_addr = $::consul::http_addr
     }
 
+    case $::consul::install_method {
+      'docker': { $command = "docker exec -t consul consul reload -http-addr=${http_addr}:${consul::http_port}" }
+      default: { $command = "consul reload -http-addr=${http_addr}:${consul::http_port}" }
+    }
+
     exec { 'reload consul service':
       path        => [$::consul::bin_dir,'/bin','/usr/bin'],
-      command     => "consul reload -http-addr=${http_addr}:${consul::http_port}",
+      command     => $command,
       refreshonly => true,
       tries       => 3,
-      unless      => "/usr/bin/test -e ${consul::config_dir}/docker_used",
     }
-
-    exec { 'reload consul service docker':
-      path        => [$::consul::bin_dir,'/bin','/usr/bin'],
-      command     => "docker restart consul",
-      refreshonly => true,
-      tries       => 3,
-      onlyif      => "/usr/bin/test -e ${consul::config_dir}/docker_used",
-    }
-
   }
-
 }

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -9,7 +9,7 @@ class consul::reload_service {
 
   # Don't attempt to reload if we're not supposed to be running.
   # This can happen during pre-provisioning of a node.
-  if $::consul::manage_service == true and $::consul::service_ensure == 'running' {
+  if $::consul::manage_service_real == true and $::consul::service_ensure == 'running' {
 
     # Make sure we don't try to connect to 0.0.0.0, use 127.0.0.1 instead
     # This can happen if the consul agent RPC port is bound to 0.0.0.0

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -9,7 +9,7 @@ class consul::reload_service {
 
   # Don't attempt to reload if we're not supposed to be running.
   # This can happen during pre-provisioning of a node.
-  if $::consul::manage_service_real == true and $::consul::service_ensure == 'running' {
+  if $::consul::manage_service == true and $::consul::service_ensure == 'running' {
 
     # Make sure we don't try to connect to 0.0.0.0, use 127.0.0.1 instead
     # This can happen if the consul agent RPC port is bound to 0.0.0.0
@@ -20,7 +20,7 @@ class consul::reload_service {
     }
 
     case $::consul::install_method {
-      'docker': { $command = "docker exec -t consul consul reload -http-addr=${http_addr}:${consul::http_port}" }
+      'docker': { $command = "docker exec consul consul reload -http-addr=${http_addr}:${consul::http_port}" }
       default: { $command = "consul reload -http-addr=${http_addr}:${consul::http_port}" }
     }
 

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -33,6 +33,16 @@ class consul::run_service {
       unless    => "consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'",
       subscribe => Service['consul'],
     }
+
+    exec { 'join consul wan docker':
+      cwd       => $::consul::config_dir,
+      path      => [$::consul::bin_dir,'/bin','/usr/bin'],
+      command   => "docker exec -t consul consul join -wan ${consul::join_wan}",
+      onlyif    => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+      unless    => "docker exec -t consul consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'",
+      subscribe => Service['consul'],
+    }
+
   }
 
 }

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -5,17 +5,17 @@
 #
 class consul::run_service {
 
-  $service_name = $::consul::init_style ? {
+  $service_name = $::consul::init_style_real ? {
     'launchd' => 'io.consul.daemon',
     default   => 'consul',
   }
 
-  $service_provider = $::consul::init_style ? {
+  $service_provider = $::consul::init_style_real ? {
     'unmanaged' => undef,
-    default     => $::consul::init_style,
+    default     => $::consul::init_style_real,
   }
 
-  if $::consul::manage_service == true {
+  if $::consul::manage_service_real == true {
     service { 'consul':
       ensure   => $::consul::service_ensure,
       name     => $service_name,

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -15,13 +15,12 @@ class consul::run_service {
     default     => $::consul::init_style,
   }
 
-  if $::consul::manage_service == true {
+  if ($::consul::manage_service == true) and ($::consul::selected_install_method != 'docker') {
     service { 'consul':
       ensure   => $::consul::service_ensure,
       name     => $service_name,
       enable   => $::consul::service_enable,
       provider => $service_provider,
-      unless   => "/usr/bin/test -e ${consul::config_dir}/docker_used",
     }
   }
 

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -25,16 +25,16 @@ class consul::run_service {
   }
 
   if $::consul::install_method == 'docker' {
-    
+
     $server_mode = pick($::consul::config_hash[server], false)
-      
+
     if $server_mode {
       $env = [ '\'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}\'', '\'CONSUL_ALLOW_PRIVILEGED_PORTS=\'']
-      $docker_command = "agent -server"
+      $docker_command = 'agent -server'
     }
     else {
       $env = [ '\'CONSUL_LOCAL_CONFIG={"leave_on_terminate": true}\'' ]
-      $docker_command = "agent"
+      $docker_command = 'agent'
     }
 
     # Docker Install
@@ -48,11 +48,11 @@ class consul::run_service {
   }
 
   case $::consul::install_method {
-    'docker': { 
+    'docker': {
       $wan_command = "docker exec -t consul consul join -wan ${consul::join_wan}"
       $wan_unless = "docker exec -t consul consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'"
     }
-    default: { 
+    default: {
       $wan_command = "consul join -wan ${consul::join_wan}"
       $wan_unless = "consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'"
     }

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -38,10 +38,10 @@ class consul::run_service {
     }
 
     # Docker Install
-    docker::run { 'consul' :
+    docker::run { 'consul':
       image   => "${consul::docker_image}:${consul::version}",
       net     => 'host',
-      volumes => [ "${::consul::config_dir}:/consul/config" ],
+      volumes => [ "${::consul::config_dir}:/consul/config", "${::consul::data_dir}:/consul/data" ],
       env     => $env,
       command => $docker_command
     }

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -37,7 +37,6 @@ class consul::run_service {
       $docker_command = 'agent'
     }
 
-    # Docker Install
     docker::run { 'consul':
       image   => "${consul::docker_image}:${consul::version}",
       net     => 'host',

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -15,7 +15,7 @@ class consul::run_service {
     default     => $::consul::init_style,
   }
 
-  if ($::consul::manage_service == true) and ($::consul::selected_install_method != 'docker') {
+  if $::consul::manage_service == true {
     service { 'consul':
       ensure   => $::consul::service_ensure,
       name     => $service_name,
@@ -24,25 +24,47 @@ class consul::run_service {
     }
   }
 
+  if $::consul::install_method == 'docker' {
+    
+    $server_mode = pick($::consul::config_hash[server], false)
+      
+    if $server_mode {
+      $env = [ '\'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}\'', '\'CONSUL_ALLOW_PRIVILEGED_PORTS=\'']
+      $command = "agent -server"
+    }
+    else {
+      $env = [ '\'CONSUL_LOCAL_CONFIG={"leave_on_terminate": true}\'' ]
+      $command = "agent"
+    }
+
+    # Docker Install
+    docker::run { 'consul' :
+      image   => "${consul::docker_image}:${consul::version}",
+      net     => 'host',
+      volumes => [ "${::consul::config_dir}:/consul/config" ],
+      env     => $env,
+      command => $command
+    }
+  }
+
+  case $::consul::install_method {
+    'docker': { 
+      $command = "docker exec -t consul consul join -wan ${consul::join_wan}"
+      $unless = "docker exec -t consul consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'"
+    }
+    default: { 
+      $command = "consul join -wan ${consul::join_wan}"
+      $unless = "consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'"
+    }
+  }
+
   if $::consul::join_wan {
     exec { 'join consul wan':
       cwd       => $::consul::config_dir,
       path      => [$::consul::bin_dir,'/bin','/usr/bin'],
-      command   => "consul join -wan ${consul::join_wan}",
-      onlyif    => "/usr/bin/test ! -e ${consul::config_dir}/docker_used",
-      unless    => "consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'",
+      command   => $command,
+      unless    => $unless,
       subscribe => Service['consul'],
     }
-
-    exec { 'join consul wan docker':
-      cwd       => $::consul::config_dir,
-      path      => [$::consul::bin_dir,'/bin','/usr/bin'],
-      command   => "docker exec -t consul consul join -wan ${consul::join_wan}",
-      onlyif    => "/usr/bin/test -e ${consul::config_dir}/docker_used",
-      unless    => "docker exec -t consul consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'",
-      subscribe => Service['consul'],
-    }
-
   }
-
 }

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -21,6 +21,7 @@ class consul::run_service {
       name     => $service_name,
       enable   => $::consul::service_enable,
       provider => $service_provider,
+      unless   => "/usr/bin/test -e ${consul::config_dir}/docker_used",
     }
   }
 
@@ -29,6 +30,7 @@ class consul::run_service {
       cwd       => $::consul::config_dir,
       path      => [$::consul::bin_dir,'/bin','/usr/bin'],
       command   => "consul join -wan ${consul::join_wan}",
+      onlyif    => "/usr/bin/test ! -e ${consul::config_dir}/docker_used",
       unless    => "consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'",
       subscribe => Service['consul'],
     }

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -29,11 +29,11 @@ class consul::run_service {
     $server_mode = pick($::consul::config_hash[server], false)
 
     if $server_mode {
-      $env = [ '\'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}\'', '\'CONSUL_ALLOW_PRIVILEGED_PORTS=\'']
+      $env = [ '\'CONSUL_ALLOW_PRIVILEGED_PORTS=\'' ]
       $docker_command = 'agent -server'
     }
     else {
-      $env = [ '\'CONSUL_LOCAL_CONFIG={"leave_on_terminate": true}\'' ]
+      $env = undef
       $docker_command = 'agent'
     }
 

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -15,7 +15,7 @@ class consul::run_service {
     default     => $::consul::init_style_real,
   }
 
-  if $::consul::manage_service_real == true {
+  if $::consul::manage_service == true and $::consul::install_method != 'docker' {
     service { 'consul':
       ensure   => $::consul::service_ensure,
       name     => $service_name,
@@ -48,8 +48,8 @@ class consul::run_service {
 
   case $::consul::install_method {
     'docker': {
-      $wan_command = "docker exec -t consul consul join -wan ${consul::join_wan}"
-      $wan_unless = "docker exec -t consul consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'"
+      $wan_command = "docker exec consul consul join -wan ${consul::join_wan}"
+      $wan_unless = "docker exec consul consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'"
     }
     default: {
       $wan_command = "consul join -wan ${consul::join_wan}"

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -30,11 +30,11 @@ class consul::run_service {
       
     if $server_mode {
       $env = [ '\'CONSUL_LOCAL_CONFIG={"skip_leave_on_interrupt": true}\'', '\'CONSUL_ALLOW_PRIVILEGED_PORTS=\'']
-      $command = "agent -server"
+      $docker_command = "agent -server"
     }
     else {
       $env = [ '\'CONSUL_LOCAL_CONFIG={"leave_on_terminate": true}\'' ]
-      $command = "agent"
+      $docker_command = "agent"
     }
 
     # Docker Install
@@ -43,18 +43,18 @@ class consul::run_service {
       net     => 'host',
       volumes => [ "${::consul::config_dir}:/consul/config" ],
       env     => $env,
-      command => $command
+      command => $docker_command
     }
   }
 
   case $::consul::install_method {
     'docker': { 
-      $command = "docker exec -t consul consul join -wan ${consul::join_wan}"
-      $unless = "docker exec -t consul consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'"
+      $wan_command = "docker exec -t consul consul join -wan ${consul::join_wan}"
+      $wan_unless = "docker exec -t consul consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'"
     }
     default: { 
-      $command = "consul join -wan ${consul::join_wan}"
-      $unless = "consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'"
+      $wan_command = "consul join -wan ${consul::join_wan}"
+      $wan_unless = "consul members -wan -detailed | grep -vP \"dc=${consul::config_hash_real['datacenter']}\" | grep -P 'alive'"
     }
   }
 
@@ -62,8 +62,8 @@ class consul::run_service {
     exec { 'join consul wan':
       cwd       => $::consul::config_dir,
       path      => [$::consul::bin_dir,'/bin','/usr/bin'],
-      command   => $command,
-      unless    => $unless,
+      command   => $wan_command,
+      unless    => $wan_unless,
       subscribe => Service['consul'],
     }
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -64,23 +64,25 @@ define consul::service(
   }
 
   $escaped_id = regsubst($id,'\/','_','G')
-  file { "${consul::config_dir}/service_${escaped_id}.json":
-    ensure  => $ensure,
-    owner   => $::consul::user,
-    group   => $::consul::group,
-    mode    => $::consul::config_mode,
-    content => consul_sorted_json($service_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-    require => File[$::consul::config_dir],
-    notify  => Class['consul::reload_service'],
-    unless  => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+
+  if $::consul::selected_install_method != 'docker' {
+    file { "${consul::config_dir}/service_${escaped_id}.json":
+      ensure  => $ensure,
+      owner   => $::consul::user,
+      group   => $::consul::group,
+      mode    => $::consul::config_mode,
+      content => consul_sorted_json($service_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+      require => File[$::consul::config_dir],
+      notify  => Class['consul::reload_service'],
+    }
   }
-  
-  file { "${consul::config_dir}/service_${escaped_id}.json":
-    ensure  => $ensure,
-    mode    => $::consul::config_mode,
-    content => consul_sorted_json($service_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-    require => File[$::consul::config_dir],
-    notify  => Class['consul::reload_service'],
-    onlyif  => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+  else {
+    file { "${consul::config_dir}/service_${escaped_id}.json":
+      ensure  => $ensure,
+      mode    => $::consul::config_mode,
+      content => consul_sorted_json($service_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+      require => File[$::consul::config_dir],
+      notify  => Class['consul::reload_service'],
+    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -66,8 +66,8 @@ define consul::service(
   $escaped_id = regsubst($id,'\/','_','G')
   file { "${consul::config_dir}/service_${escaped_id}.json":
     ensure  => $ensure,
-    owner   => $::consul::user,
-    group   => $::consul::group,
+    owner   => $::consul::user_real,
+    group   => $::consul::group_real,
     mode    => $::consul::config_mode,
     content => consul_sorted_json($service_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
     require => File[$::consul::config_dir],

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -71,6 +71,5 @@ define consul::service(
     mode    => $::consul::config_mode,
     content => consul_sorted_json($service_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
     require => File[$::consul::config_dir],
-    notify  => Class['consul::reload_service'],
-  }
+  } ~> Class['consul::reload_service']
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -71,5 +71,16 @@ define consul::service(
     mode    => $::consul::config_mode,
     content => consul_sorted_json($service_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
     require => File[$::consul::config_dir],
-  } ~> Class['consul::reload_service']
+    notify  => Class['consul::reload_service'],
+    unless  => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+  }
+  
+  file { "${consul::config_dir}/service_${escaped_id}.json":
+    ensure  => $ensure,
+    mode    => $::consul::config_mode,
+    content => consul_sorted_json($service_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+    require => File[$::consul::config_dir],
+    notify  => Class['consul::reload_service'],
+    onlyif  => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -64,25 +64,13 @@ define consul::service(
   }
 
   $escaped_id = regsubst($id,'\/','_','G')
-
-  if $::consul::selected_install_method != 'docker' {
-    file { "${consul::config_dir}/service_${escaped_id}.json":
-      ensure  => $ensure,
-      owner   => $::consul::user,
-      group   => $::consul::group,
-      mode    => $::consul::config_mode,
-      content => consul_sorted_json($service_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-      require => File[$::consul::config_dir],
-      notify  => Class['consul::reload_service'],
-    }
-  }
-  else {
-    file { "${consul::config_dir}/service_${escaped_id}.json":
-      ensure  => $ensure,
-      mode    => $::consul::config_mode,
-      content => consul_sorted_json($service_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-      require => File[$::consul::config_dir],
-      notify  => Class['consul::reload_service'],
-    }
+  file { "${consul::config_dir}/service_${escaped_id}.json":
+    ensure  => $ensure,
+    owner   => $::consul::user,
+    group   => $::consul::group,
+    mode    => $::consul::config_mode,
+    content => consul_sorted_json($service_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+    require => File[$::consul::config_dir],
+    notify  => Class['consul::reload_service'],
   }
 }

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -136,8 +136,8 @@ define consul::watch(
   file { "watch_${id} with consul users" :
     path    => "${consul::config_dir}/watch_${id}.json",
     ensure  => $ensure,
-    owner   => $::consul::user,
-    group   => $::consul::group,
+    owner   => $::consul::user_real,
+    group   => $::consul::group_real,
     mode    => $::consul::config_mode,
     content => consul_sorted_json($watch_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
     notify  => Class['consul::reload_service'],

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -133,24 +133,26 @@ define consul::watch(
     watches => [delete_undef_values(merge($basic_hash, $type_hash))]
   }
 
-  File[$::consul::config_dir]
-  -> file { "watch_${id} with consul users":
-    path    => "${consul::config_dir}/watch_${id}.json",
-    ensure  => $ensure,
-    owner   => $::consul::user,
-    group   => $::consul::group,
-    mode    => $::consul::config_mode,
-    content => consul_sorted_json($watch_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-    notify  => Class['consul::reload_service'],
-    unless  => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+  if $::consul::selected_install_method != 'docker' {
+    file { "watch_${id} with consul users" :
+      path    => "${consul::config_dir}/watch_${id}.json",
+      ensure  => $ensure,
+      owner   => $::consul::user,
+      group   => $::consul::group,
+      mode    => $::consul::config_mode,
+      content => consul_sorted_json($watch_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+      notify  => Class['consul::reload_service'],
+      require => File[$::consul::config_dir],
+    }
   }
-  -> file { "watch_${id} without consul users":
-    path    => "${consul::config_dir}/watch_${id}.json",
-    ensure  => $ensure,
-    mode    => $::consul::config_mode,
-    content => consul_sorted_json($watch_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-    notify  => Class['consul::reload_service'],
-    onlyif  => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+  else {
+    file { "watch_${id} without consul users" :
+      path    => "${consul::config_dir}/watch_${id}.json",
+      ensure  => $ensure,
+      mode    => $::consul::config_mode,
+      content => consul_sorted_json($watch_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+      notify  => Class['consul::reload_service'],
+      require => File[$::consul::config_dir],
+    }
   }
-
 }

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -134,7 +134,7 @@ define consul::watch(
   }
 
   File[$::consul::config_dir]
-  -> file { "${consul::config_dir}/watch_${id}.json" :
+  -> file { "${consul::config_dir}/watch_${id}.json":
     ensure  => $ensure,
     owner   => $::consul::user_real,
     group   => $::consul::group_real,

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -134,11 +134,23 @@ define consul::watch(
   }
 
   File[$::consul::config_dir]
-  -> file { "${consul::config_dir}/watch_${id}.json":
+  -> file { "watch_${id} with consul users":
+    path    => "${consul::config_dir}/watch_${id}.json",
     ensure  => $ensure,
     owner   => $::consul::user,
     group   => $::consul::group,
     mode    => $::consul::config_mode,
     content => consul_sorted_json($watch_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-  } ~> Class['consul::reload_service']
+    notify  => Class['consul::reload_service'],
+    unless  => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+  }
+  -> file { "watch_${id} without consul users":
+    path    => "${consul::config_dir}/watch_${id}.json",
+    ensure  => $ensure,
+    mode    => $::consul::config_mode,
+    content => consul_sorted_json($watch_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+    notify  => Class['consul::reload_service'],
+    onlyif  => "/usr/bin/test -e ${consul::config_dir}/docker_used",
+  }
+
 }

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -133,26 +133,15 @@ define consul::watch(
     watches => [delete_undef_values(merge($basic_hash, $type_hash))]
   }
 
-  if $::consul::selected_install_method != 'docker' {
-    file { "watch_${id} with consul users" :
-      path    => "${consul::config_dir}/watch_${id}.json",
-      ensure  => $ensure,
-      owner   => $::consul::user,
-      group   => $::consul::group,
-      mode    => $::consul::config_mode,
-      content => consul_sorted_json($watch_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-      notify  => Class['consul::reload_service'],
-      require => File[$::consul::config_dir],
-    }
+  file { "watch_${id} with consul users" :
+    path    => "${consul::config_dir}/watch_${id}.json",
+    ensure  => $ensure,
+    owner   => $::consul::user,
+    group   => $::consul::group,
+    mode    => $::consul::config_mode,
+    content => consul_sorted_json($watch_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+    notify  => Class['consul::reload_service'],
+    require => File[$::consul::config_dir],
   }
-  else {
-    file { "watch_${id} without consul users" :
-      path    => "${consul::config_dir}/watch_${id}.json",
-      ensure  => $ensure,
-      mode    => $::consul::config_mode,
-      content => consul_sorted_json($watch_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-      notify  => Class['consul::reload_service'],
-      require => File[$::consul::config_dir],
-    }
-  }
+
 }

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -133,15 +133,13 @@ define consul::watch(
     watches => [delete_undef_values(merge($basic_hash, $type_hash))]
   }
 
-  file { "watch_${id} with consul users" :
+  File[$::consul::config_dir]
+  -> file { "${consul::config_dir}/watch_${id}.json" :
     ensure  => $ensure,
-    path    => "${consul::config_dir}/watch_${id}.json",
     owner   => $::consul::user_real,
     group   => $::consul::group_real,
     mode    => $::consul::config_mode,
     content => consul_sorted_json($watch_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-    notify  => Class['consul::reload_service'],
-    require => File[$::consul::config_dir],
-  }
+  } ~> Class['consul::reload_service']
 
 }

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -134,8 +134,8 @@ define consul::watch(
   }
 
   file { "watch_${id} with consul users" :
-    path    => "${consul::config_dir}/watch_${id}.json",
     ensure  => $ensure,
+    path    => "${consul::config_dir}/watch_${id}.json",
     owner   => $::consul::user_real,
     group   => $::consul::group_real,
     mode    => $::consul::config_mode,

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,6 @@
 {
   "name": "KyleAnderson-consul",
+  "version": "3.1.0",
   "author": "Kyle Anderson <kyle@xkyle.com>",
   "summary": "Configures Consul by Hashicorp",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,5 @@
 {
   "name": "KyleAnderson-consul",
-  "version": "3.0.0",
   "author": "Kyle Anderson <kyle@xkyle.com>",
   "summary": "Configures Consul by Hashicorp",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "KyleAnderson-consul",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "Kyle Anderson <kyle@xkyle.com>",
   "summary": "Configures Consul by Hashicorp",
   "license": "Apache-2.0",


### PR DESCRIPTION
added two new install_methods:  auto and docker (neither set to default).

docker now uses the official docker container to deploy but still calls config_hash and mounts the config_dir for consistency.  Image can be chosen, but network and certain key variables are hardcoded per consul recomendations for use in a container by the host.  See: https://hub.docker.com/_/consul/

auto will look for the [docker0] network interface.  If found, it uses docker, on failure it falls back to the url default.

The default remains at "url", disabling this feature.

