### PR TITLE
Fix issue with init script

### DIFF
--- a/templates/consul.init.erb
+++ b/templates/consul.init.erb
@@ -101,6 +101,14 @@ stop() {
         return $retcode
 }
 
+status() {
+        "$CONSUL" info ${HTTP_ADDR}
+        consul_pid=$(cat $PID_FILE)
+        checkpid $consul_pid
+        retcode=$?
+        exit $retcode
+}
+
 case "$1" in
     start)
         start
@@ -109,7 +117,7 @@ case "$1" in
         stop
         ;;
     status)
-        "$CONSUL" info ${HTTP_ADDR}
+        status
         ;;
     restart)
         stop


### PR DESCRIPTION
When you don't have permission to access the server, this script will return error 403. This changes the script to run checkpid for the status check. Original script causes idempotency issues when you don't have permission to run consul info