### PR TITLE
use proper systemd custom .service directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,7 +34,7 @@ class consul::config(
         }
       }
       'systemd': {
-        file { '/lib/systemd/system/consul.service':
+        file { '/etc/systemd/system/consul.service':
           mode    => '0644',
           owner   => 'root',
           group   => 'root',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -640,7 +640,7 @@ describe 'consul' do
     }}
 
     it { should contain_class('consul').with_init_style('systemd') }
-    it { should contain_file('/lib/systemd/system/consul.service').with_content(/consul agent/) }
+    it { should contain_file('/etc/systemd/system/consul.service').with_content(/consul agent/) }
   end
 
   context "On an Amazon based OS" do
@@ -662,7 +662,7 @@ describe 'consul' do
     }}
 
     it { should contain_class('consul').with_init_style('systemd') }
-    it { should contain_file('/lib/systemd/system/consul.service').with_content(/consul agent/) }
+    it { should contain_file('/etc/systemd/system/consul.service').with_content(/consul agent/) }
   end
 
   context "On a fedora 20 based OS" do
@@ -673,7 +673,7 @@ describe 'consul' do
     }}
 
     it { should contain_class('consul').with_init_style('systemd') }
-    it { should contain_file('/lib/systemd/system/consul.service').with_content(/consul agent/) }
+    it { should contain_file('/etc/systemd/system/consul.service').with_content(/consul agent/) }
   end
 
   context "On hardy" do
@@ -698,14 +698,14 @@ describe 'consul' do
     }}
 
     it { should contain_class('consul').with_init_style('systemd') }
-    it { should contain_file('/lib/systemd/system/consul.service').with_content(/consul agent/) }
+    it { should contain_file('/etc/systemd/system/consul.service').with_content(/consul agent/) }
   end
 
   context "When asked not to manage the init system" do
     let(:params) {{ :init_style => 'unmanaged' }}
     it { should contain_class('consul').with_init_style('unmanaged') }
     it { should_not contain_file("/etc/init.d/consul") }
-    it { should_not contain_file("/lib/systemd/system/consul.service") }
+    it { should_not contain_file("/etc/systemd/system/consul.service") }
   end
 
   context "On squeeze" do


### PR DESCRIPTION
The upstream (package manager) files should not be modified.
Instead the custom/generated .service files should be put in the /etc/systemd/ directory which by default overrides any files in /lib/.