### PR TITLE
Validate config file before deploying

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -106,13 +106,14 @@ class consul::config(
     recurse => $purge,
   }
   -> file { 'consul config.json':
-    ensure  => present,
-    path    => "${consul::config_dir}/config.json",
-    owner   => $::consul::user_real,
-    group   => $::consul::group_real,
-    mode    => $::consul::config_mode,
-    content => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-    require => File[$::consul::config_dir],
+    ensure       => present,
+    path         => "${consul::config_dir}/config.json",
+    owner        => $::consul::user_real,
+    group        => $::consul::group_real,
+    mode         => $::consul::config_mode,
+    content      => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+    require      => File[$::consul::config_dir],
+    validate_cmd => "${::consul::bin_dir}/consul validate % > /dev/null",
   }
 
 }


### PR DESCRIPTION
Use validate_cmd to check the config file for validity before actually installing it.