### PR TITLE
Using the right config validation command

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -113,7 +113,7 @@ class consul::config(
     mode         => $::consul::config_mode,
     content      => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
     require      => File[$::consul::config_dir],
-    validate_cmd => "${::consul::bin_dir}/consul validate % > /dev/null",
+    validate_cmd => "${::consul::bin_dir}/consul configtest -config-file % > /dev/null",
   }
 
 }


### PR DESCRIPTION
_consul_'s validation command is actually `configtest` which takes the config file as `-config-file ARG` argument.
The current version failed because `consul validate` exited with an error:
```
Error: Execution of '/usr/local/bin/consul validate /etc/consul/config.json20171025-8511-7229zs > /dev/null' returned 1: usage: consul [--version] [--help] <command> [<args>]

Available commands are:
    agent          Runs a Consul agent
    configtest     Validate config file
    event          Fire a new event
    exec           Executes a command on Consul nodes
    force-leave    Forces a member of the cluster to enter the "left" state
    info           Provides debugging information for operators
    join           Tell Consul agent to join cluster
    keygen         Generates a new encryption key
    keyring        Manages gossip layer encryption keys
    kv             Interact with the key-value store
    leave          Gracefully leaves the Consul cluster and shuts down
    lock           Execute a command holding a lock
    maint          Controls node or service maintenance mode
    members        Lists the members of a Consul cluster
    monitor        Stream logs from a Consul agent
    operator       Provides cluster-level tools for Consul operators
    reload         Triggers the agent to reload configuration files
    rtt            Estimates network round trip time between nodes
    snapshot       Saves, restores and inspects snapshots of Consul server state
    version        Prints the Consul version
    watch          Watch for changes in Consul
```
