### PR TITLE
Fix validate command for config files in consul 1.0.0

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -113,7 +113,7 @@ class consul::config(
     mode         => $::consul::config_mode,
     content      => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
     require      => File[$::consul::config_dir],
-    validate_cmd => "${::consul::bin_dir}/consul validate % > /dev/null",
+    validate_cmd => "${::consul::bin_dir}/consul validate $(ln -s % /tmp/consul-config.json && echo \"/tmp/consul-config.json\") > /dev/null",
   }
 
 }


### PR DESCRIPTION
The consul validate command has a problem with using files which do not end in .json or .hcl which is the fact when using validate_cmd which uses a temporary file and puppet adds a tmp-specific string. This solution is kind of an ugly workaround which produces a tmp link file with the correct name and leaves it in /tmp. After the check this link will become invalid and there are no security issues.

The consul maintainers are discussing about a better solution here https://github.com/hashicorp/consul/issues/3620 but we need a solution right now and that fixed it for us. This could maybe be removed after consul adds a fix for this issue.