### PR TITLE
Removing the consul config check

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -106,14 +106,13 @@ class consul::config(
     recurse => $purge,
   }
   -> file { 'consul config.json':
-    ensure       => present,
-    path         => "${consul::config_dir}/config.json",
-    owner        => $::consul::user_real,
-    group        => $::consul::group_real,
-    mode         => $::consul::config_mode,
-    content      => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
-    require      => File[$::consul::config_dir],
-    validate_cmd => "${::consul::bin_dir}/consul validate $(ln -sf % /tmp/consul-config.json && echo \"/tmp/consul-config.json\") > /dev/null",
+    ensure  => present,
+    path    => "${consul::config_dir}/config.json",
+    owner   => $::consul::user_real,
+    group   => $::consul::group_real,
+    mode    => $::consul::config_mode,
+    content => consul_sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
+    require => File[$::consul::config_dir],
   }
 
 }


### PR DESCRIPTION
Originally this config check wasn't working with the newest consul version and a workaround with saving it temporarily was introduced. When updating the configuration this check wasn't working either so it is safer to remove it and leave it to the developer to set the correct information.

The new consul config check has a posibility to circumvent the original problem that the configuration file wasn't ending in ".json" but this would also introduce checking before which consul version is running.

This PR is regarding: https://github.com/solarkennedy/puppet-consul/pull/377#event-1314047133