### PR TITLE
allow "args" and "script" for consul check config

### DIFF
--- a/lib/puppet/parser/functions/consul_validate_checks.rb
+++ b/lib/puppet/parser/functions/consul_validate_checks.rb
@@ -5,23 +5,23 @@ def validate_checks(obj)
         validate_checks(c)
       end
     when Hash
-        if ( (obj.key?("http") || obj.key?("script") || obj.key?("tcp")) && (! obj.key?("interval")) )
+        if ( (obj.key?("http") || ( obj.key?("script") || obj.key?("args") ) || obj.key?("tcp")) && (! obj.key?("interval")) )
           raise Puppet::ParseError.new('interval must be defined for tcp, http, and script checks')
         end
 
         if obj.key?("ttl")
-          if (obj.key?("http") || obj.key?("script") || obj.key?("tcp") || obj.key?("interval"))
+          if (obj.key?("http") || ( obj.key?("args") || obj.key?("script") ) || obj.key?("tcp") || obj.key?("interval"))
             raise Puppet::ParseError.new('script, http, tcp, and interval must not be defined for ttl checks')
           end
         elsif obj.key?("http")
-          if (obj.key?("script") || obj.key?("tcp"))
+          if (( obj.key?("args") || obj.key?("script") ) || obj.key?("tcp"))
             raise Puppet::ParseError.new('script and tcp must not be defined for http checks')
           end
         elsif obj.key?("tcp")
-          if (obj.key?("http") || obj.key?("script"))
+          if (obj.key?("http") || ( obj.key?("args") || obj.key?("script") ))
             raise Puppet::ParseError.new('script and http must not be defined for tcp checks')
           end
-        elsif obj.key?("script")
+        elsif ( obj.key?("args") || obj.key?("script") )
           if (obj.key?("http") || obj.key?("tcp"))
             raise Puppet::ParseError.new('http and tcp must not be defined for script checks')
           end


### PR DESCRIPTION
- the script config is deprecated as of Consul 1.0.0 [0]

[0] https://github.com/hashicorp/consul/blob/master/CHANGELOG.md#100-october-16-2017