### PR TITLE
Fixes #360 by setting config_dir under FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,6 @@ class consul::params {
   $bin_dir               = '/usr/local/bin'
   $checks                = {}
   $config_defaults       = {}
-  $config_dir            = '/etc/consul'
   $config_hash           = {}
   $config_mode           = '0664'
   $docker_image          = 'consul'
@@ -48,6 +47,11 @@ class consul::params {
     default:           {
       fail("Unsupported kernel architecture: ${::architecture}")
     }
+  }
+
+  $config_dir = $::osfamily ? {
+    'FreeBSD' => '/usr/local/etc/consul.d',
+    default   => '/etc/consul'
   }
 
   $os = downcase($::kernel)

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -717,6 +717,17 @@ describe 'consul' do
     it { should contain_class('consul').with_init_style('systemd') }
   end
 
+
+  context "On FreeBSD" do
+    let(:facts) {{
+      :operatingsystem => 'FreeBSD',
+      :operatingsystemrelease => '10.3',
+      :osfamily => 'FreeBSD'
+    }}
+
+    it { should contain_file('/usr/local/etc/consul.d').with(:purge => true,:recurse => true) }
+  end
+
   # Config Stuff
   context "With extra_options" do
     let(:params) {{

--- a/templates/consul.freebsd.erb
+++ b/templates/consul.freebsd.erb
@@ -34,11 +34,12 @@ load_rc_config $name
 : ${consul_dir:="/var/tmp/consul"}
 : ${consul_env:=""}
 : ${consul_log_file:="/dev/null"}
+: ${consul_config_dir:="<%= scope.lookupvar('consul::config_dir') %>"}
 
 pidfile=/var/run/consul.pid
 procname="/usr/local/bin/consul"
 command="/usr/sbin/daemon"
-command_args="-p ${pidfile} /usr/bin/env ${consul_env} ${procname} agent -data-dir=${consul_dir} -config-dir=/usr/local/etc/consul.d ${consul_args} >> ${consul_log_file}"
+command_args="-p ${pidfile} /usr/bin/env ${consul_env} ${procname} agent -data-dir=${consul_dir} -config-dir=${consul_config_dir} ${consul_args} >> ${consul_log_file}"
 
 start_precmd=consul_startprecmd
 


### PR DESCRIPTION
This change addressing #360 by updating the params to set config_dir to `/usr/local/etc/consul.d` under FreeBSD. This also adds the piping to update the ERB template for the aforementioned param.