### PR TITLE
fix typo in check timeout

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -70,7 +70,7 @@ define consul::check(
     'script'     => $script,
     'tcp'        => $tcp,
     'interval'   => $interval,
-    'timeout '   => $timeout,
+    'timeout'   => $timeout,
     'service_id' => $service_id,
     'notes'      => $notes,
     'token'      => $token,


### PR DESCRIPTION
- causes consul 1.X to fail on start