### PR TITLE
Do not unquote integers with a starting zero

### DIFF
--- a/lib/puppet/parser/functions/consul_sorted_json.rb
+++ b/lib/puppet/parser/functions/consul_sorted_json.rb
@@ -82,7 +82,7 @@ module JSON
         else
           # Should be a string
           # keep string integers unquoted
-          (obj =~ /\A[-]?\d+\z/) ? obj : obj.to_json
+          (obj =~ /\A[-]?[1-9]\d*\z/) ? obj : obj.to_json
       end
     end
 

--- a/lib/puppet/parser/functions/consul_sorted_json.rb
+++ b/lib/puppet/parser/functions/consul_sorted_json.rb
@@ -82,7 +82,7 @@ module JSON
         else
           # Should be a string
           # keep string integers unquoted
-          (obj =~ /\A[-]?[1-9]\d*\z/) ? obj : obj.to_json
+          (obj =~ /\A[-]?(0|[1-9]\d*)\z/) ? obj : obj.to_json
       end
     end
 

--- a/spec/functions/consul_sorted_json_spec.rb
+++ b/spec/functions/consul_sorted_json_spec.rb
@@ -28,6 +28,12 @@ RSpec.shared_examples 'handling_simple_types' do |pretty|
   it 'handles integer in a string' do
     expect(subject.call([{'key' => '1' }],pretty)).to eql('{"key":1}')
   end
+  it 'handles zero in a string' do
+    expect(subject.call([{'key' => '0' }],pretty)).to eql('{"key":0}')
+  end
+  it 'handles integers with a leading zero in a string' do
+    expect(subject.call([{'key' => '0640' }],pretty)).to eql('{"key":"0640"}')
+  end
   it 'handles negative integer in a string' do
     expect(subject.call([{'key' => '-1' }],pretty)).to eql('{"key":-1}')
   end


### PR DESCRIPTION
Integers with leading zeros are invalid in JSON, so they should probably stay quoted in. (They would be valid Javascript, but JSON does not support octal notation as stated on http://json.org.

Fixes #389