### PR TITLE
Add `args` parameter to `consul::check`

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -23,7 +23,11 @@
 #
 # [*script*]
 #   Full path to the location of the healthcheck script. Must be nagios
-#   compliant with regards to the return codes.
+#   compliant with regards to the return codes. This parameter is deprecated
+#   in Consul 1.0.0, see https://github.com/hashicorp/consul/issues/3509.
+#
+# [*args*]
+#   Arguments to be `exec`ed for the healthcheck script.
 #
 # [*service_id*]
 #   An optional service_id to match this check against
@@ -53,6 +57,7 @@ define consul::check(
   $interval   = undef,
   $notes      = undef,
   $script     = undef,
+  $args       = undef,
   $service_id = undef,
   $status     = undef,
   $tcp        = undef,
@@ -68,9 +73,10 @@ define consul::check(
     'ttl'        => $ttl,
     'http'       => $http,
     'script'     => $script,
+    'args'       => $args,
     'tcp'        => $tcp,
     'interval'   => $interval,
-    'timeout'   => $timeout,
+    'timeout'    => $timeout,
     'service_id' => $service_id,
     'notes'      => $notes,
     'token'      => $token,

--- a/spec/defines/consul_check_spec.rb
+++ b/spec/defines/consul_check_spec.rb
@@ -27,6 +27,20 @@ describe 'consul::check' do
         .with_content(/"script" *: *"true"/)
     }
   end
+  describe 'with args' do
+    let(:params) {{
+      'interval' => '30s',
+      'args'     => ['sh', '-c', 'true'],
+    }}
+    it {
+      should contain_file("/etc/consul/check_my_check.json") \
+        .with_content(/"id" *: *"my_check"/) \
+        .with_content(/"name" *: *"my_check"/) \
+        .with_content(/"check" *: *\{/) \
+        .with_content(/"interval" *: *"30s"/) \
+        .with_content(/"args" *: *\[ *"sh", *"-c", *"true" *\]/)
+    }
+  end
   describe 'with script and service_id' do
     let(:params) {{
       'interval'    => '30s',


### PR DESCRIPTION
#382 added support for the `args` parameter to the `consul_validate_checks` function, but it isn't accepted by the `consul::check` resource.