### PR TITLE
Removed command substitution in init script

### DIFF
--- a/templates/consul.init.erb
+++ b/templates/consul.init.erb
@@ -54,7 +54,7 @@ start() {
         [ -f $PID_FILE ] && rm $PID_FILE
         daemon --user=<%= scope.lookupvar('consul::user') %> \
             --pidfile="$PID_FILE" \
-            $("$CONSUL" agent -pid-file "${PID_FILE}" -config-dir "$CONFIG" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE" &)
+            "$CONSUL" agent -pid-file "${PID_FILE}" -config-dir "$CONFIG" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE" &
         retcode=$?
         echo
         [ $retcode = 0 ] && touch /var/lock/subsys/consul


### PR DESCRIPTION
This command substitution causes Consul to be launched as root instead as the non-privileged user.
(Tested on AmazonLinux1)