### PR TITLE
Added experimental Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ new versions of consul. Pin to the version that works for your setup!
   * If installing from docker, you *must* ensure puppetlabs-docker_platform module is available.
 * Optionally installs a user to run it under
 * Installs a configuration file (/etc/consul/config.json)
-* Manages the consul service via upstart, sysv, or systemd
+* Manages the consul service via upstart, sysv, systemd, or nssm.
 * Optionally installs the Web UI
 
 ## Usage
@@ -280,6 +280,30 @@ The optional parameters only need to be specified if you require changes from de
 
 Depends on the JSON gem, or a modern ruby. (Ruby 1.8.7 is not officially supported)
 Depending on the version of puppetserver deployed it may not be new enough (1.8.0 is too old, 2.0.3 is known to work).
+
+## Windows Experimental Support
+
+Windows service support is provided by [NSSM](https://nssm.cc), which is expected to be installed separately. The following caveats apply:
+
+ * The user and group parameter must be different (Administrator/Administrators recommended).
+ * The NSSM executable must be passed as a parameter like in the following example:
+
+```puppet
+class { '::consul':
+  nssm_exec   => 'C:/Program Files/nssm/nssm-2.24/win64/nssm.exe',
+  bin_dir     => 'C:/Consul',
+  user        => 'Administrator',
+  group       => 'Administrators',
+  config_hash => {
+    'bootstrap_expect' => 1,
+    'data_dir'         => 'C:/Consul',
+    'datacenter'       => 'dc1',
+    'log_level'        => 'INFO',
+    'node_name'        => 'server',
+    'server'           => true,
+  }
+}
+```
 
 ## Consul Template
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,6 +75,9 @@
 # [*manage_user*]
 #   Whether to create/manage the user that should own consul's configuration files.
 #
+# [*nssm_exec*]
+#   Location of nssm windows binary for service management
+#
 # [*os*]
 #   OS component in the name of the archive file containing the consul binary.
 #
@@ -157,6 +160,7 @@ class consul (
   Boolean $manage_group                      = $consul::params::manage_group,
   Boolean $manage_service                    = $consul::params::manage_service,
   Boolean $manage_user                       = $consul::params::manage_user,
+  Optional[String] $nssm_exec                = undef,
   $os                                        = $consul::params::os,
   $package_ensure                            = $consul::params::package_ensure,
   $package_name                              = $consul::params::package_name,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -65,9 +65,9 @@ class consul::install {
       }
       -> file {
         "${install_path}/consul-${consul::version}/${binary_name}":
-          owner  => $binary_owner,
-          group  => $binary_group,
-          mode   => $binary_mode;
+          owner => $binary_owner,
+          group => $binary_group,
+          mode  => $binary_mode;
         "${consul::bin_dir}/${binary_name}":
           ensure => link,
           notify => $do_notify_service,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,6 +4,24 @@
 #
 class consul::install {
 
+  case $::operatingsystem {
+    'windows': {
+      $binary_name = 'consul.exe'
+      $binary_mode = '0775'
+      $data_dir_mode = '775'
+      $binary_owner = 'Administrators'
+      $binary_group = 'Administrators'
+    }
+    default: {
+      $binary_name = 'consul'
+      $binary_mode = '0555'
+      $data_dir_mode = '755'
+      # 0 instead of root because OS X uses "wheel".
+      $binary_owner = 'root'
+      $binary_group = 0
+    }
+  }
+
   if $consul::data_dir {
     file { $consul::data_dir:
       ensure => 'directory',
@@ -33,9 +51,9 @@ class consul::install {
         $install_path,
         "${install_path}/consul-${consul::version}"]:
         ensure => directory,
-        owner  => 'root',
-        group  => 0, # 0 instead of root because OS X uses "wheel".
-        mode   => '0555';
+        owner  => $binary_owner,
+        group  => $binary_group,
+        mode   => $binary_mode,
       }
       -> archive { "${install_path}/consul-${consul::version}.${consul::download_extension}":
         ensure       => present,
@@ -43,17 +61,17 @@ class consul::install {
         proxy_server => $consul::proxy_server,
         extract      => true,
         extract_path => "${install_path}/consul-${consul::version}",
-        creates      => "${install_path}/consul-${consul::version}/consul",
+        creates      => "${install_path}/consul-${consul::version}/${binary_name}",
       }
       -> file {
-        "${install_path}/consul-${consul::version}/consul":
-          owner => 'root',
-          group => 0, # 0 instead of root because OS X uses "wheel".
-          mode  => '0555';
-        "${consul::bin_dir}/consul":
+        "${install_path}/consul-${consul::version}/${binary_name}":
+          owner  => $binary_owner,
+          group  => $binary_group,
+          mode   => $binary_mode;
+        "${consul::bin_dir}/${binary_name}":
           ensure => link,
           notify => $do_notify_service,
-          target => "${install_path}/consul-${consul::version}/consul";
+          target => "${install_path}/consul-${consul::version}/${binary_name}";
       }
     }
     'package': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,16 +37,17 @@ class consul::params {
   $watches               = {}
 
   case $::architecture {
-    'x86_64', 'amd64': { $arch = 'amd64' }
-    'i386':            { $arch = '386'   }
-    /^arm.*/:          { $arch = 'arm'   }
-    default:           {
+    'x86_64', 'x64', 'amd64': { $arch = 'amd64' }
+    'i386':                   { $arch = '386'   }
+    /^arm.*/:                 { $arch = 'arm'   }
+    default:                  {
       fail("Unsupported kernel architecture: ${::architecture}")
     }
   }
 
   $config_dir = $::osfamily ? {
     'FreeBSD' => '/usr/local/etc/consul.d',
+    'windows' => 'c:/Consul/config',
     default   => '/etc/consul'
   }
 
@@ -112,6 +113,9 @@ class consul::params {
   } elsif $::operatingsystem == 'FreeBSD' {
     $init_style = 'freebsd'
     $shell = '/usr/sbin/nologin'
+  } elsif $::operatingsystem == 'windows' {
+    $init_style = 'unmanaged'
+    $shell = undef
   } else {
     fail('Cannot determine init_style, unsupported OS')
   }

--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -16,6 +16,12 @@ class consul::run_service {
   }
 
   if $consul::manage_service == true and $consul::install_method != 'docker' {
+    if $::operatingsystem == 'windows' {
+      class { 'consul::windows_service':
+        before => Service['consul'],
+      }
+    }
+
     service { 'consul':
       ensure   => $consul::service_ensure,
       name     => $service_name,

--- a/manifests/windows_service.pp
+++ b/manifests/windows_service.pp
@@ -1,0 +1,53 @@
+# == Class consul::windows_service
+#
+# Installs consul windows server
+# == Parameters
+#
+# [*nssm_version*]
+#   nssm version to download
+#
+# [*nssm_download_url*]
+#   nssm version to download
+#
+# [*nssm_download_url_base*]
+#   nssm version to download
+#
+class consul::windows_service {
+
+  $app_dir = regsubst($consul::bin_dir, '\/', '\\', 'G')
+  $app_exec = "${app_dir}\\consul.exe"
+  $agent_args = regsubst($consul::config_dir, '\/', '\\', 'G')
+  $app_args = "agent -config-dir=${agent_args}"
+  $app_log_path = "${app_dir}\\logs"
+  $app_log_file = 'consul.log'
+  $app_log = "${app_log_path}//${app_log_file}"
+
+  include '::archive'
+
+  file { $app_log_path:
+    ensure => 'directory',
+    owner  => 'Administrator',
+    group  => 'Administrators',
+    mode   => '0755',
+  }
+  -> exec { 'consul_service_install':
+    cwd       => $consul::bin_dir,
+    command   => "&'${consul::nssm_exec}' install Consul ${app_exec}",
+    unless    => 'if((get-service -name consul -ErrorAction SilentlyContinue).count -ne 1){exit 1}',
+    logoutput => true,
+    provider  => 'powershell',
+    notify    => Exec['consul_service_set_parameters']
+  }
+  file { "${consul::bin_dir}/set_service_parameters.ps1":
+    ensure  => 'present',
+    content => template('consul/set_service_parameters.ps1.erb'),
+    notify  => Exec['consul_service_set_parameters']
+  }
+  -> exec { 'consul_service_set_parameters':
+    cwd         => $consul::bin_dir,
+    command     => "${consul::bin_dir}/set_service_parameters.ps1",
+    refreshonly => true,
+    logoutput   => true,
+    provider    => 'powershell',
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -26,6 +26,10 @@
     {
       "name": "camptocamp/systemd",
       "version_requirement": ">= 1.1.1 < 2.0.0"
+    },
+    {
+      "name": "puppetlabs/powershell",
+      "version_requirement": ">= 2.1.3 < 3.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -118,6 +122,13 @@
         "10",
         "11",
         "12"
+      ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "Server 2012 R2",
+        "Server 2016"
       ]
     }
   ]

--- a/templates/set_service_parameters.ps1.erb
+++ b/templates/set_service_parameters.ps1.erb
@@ -1,0 +1,14 @@
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppParameters "<%= @app_args %>"
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppDirectory "<%= @app_dir %>"
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppStopMethodConsole 15000
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppStopMethodSkip 2
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppStopMethodSkip 4
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppStderr "<%= @app_log %>"
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppStdout "<%= @app_log %>"
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppRotateFiles 1
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppRotateOnline 0
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppRotateBytes 1024000
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppRestartDelay 0
+& '<%= scope['consul::nssm_exec'] %>' set Consul AppExit Default Exit
+& '<%= scope['consul::nssm_exec'] %>' set Consul Start SERVICE_AUTO_START
+exit 0


### PR DESCRIPTION
Here is a slightly modified version of #352.

- NSSM is expected to be installed prior, and the nssm executable passed as a parameter.
- Added puppetlabs-powershell as a dependency
- Tested on Windows Server 2012 R2 and 2016