### PR TITLE
Add `args` parameter to `consul::watch` 

### DIFF
--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -16,7 +16,11 @@
 #   Name of an event to watch for.
 #
 # [*handler*]
-#   Full path to the script that will be excuted.
+#   Full path to the script that will be excuted. This parameter is deprecated
+#   in Consul 1.0.0, see https://github.com/hashicorp/consul/issues/3509.
+#
+# [*args*]
+#   Arguments to be `exec`ed for the watch.
 #
 # [*key*]
 #   Watch a specific key.
@@ -44,6 +48,7 @@
 #   Type of data to watch. (Like key, service, services, nodes)
 #
 define consul::watch(
+  $args                          = undef,
   $datacenter                    = undef,
   $ensure                        = present,
   $event_name                    = undef,
@@ -62,6 +67,7 @@ define consul::watch(
 
   $basic_hash = {
     'type'       => $type,
+    'args'       => $args,
     'handler'    => $handler,
     'datacenter' => $datacenter,
     'token'      => $token,
@@ -71,8 +77,12 @@ define consul::watch(
     fail ('Watches are only supported in Consul 0.4.0 and above')
   }
 
-  if (! $handler ) {
-    fail ('All watch conditions must have a handler defined')
+  if (! $handler and ! $args) {
+    fail ('All watch conditions must have a handler or args list defined')
+  }
+
+  if ($handler and $args) {
+    fail ('Watch conditions cannot have both a handler and args list defined')
   }
 
   if (! $type ) {

--- a/spec/defines/consul_watch_spec.rb
+++ b/spec/defines/consul_watch_spec.rb
@@ -53,6 +53,29 @@ describe 'consul::watch' do
     }
   end
 
+  describe 'with valid type and args' do
+    let(:params) {{
+      'type' => 'nodes',
+      'args' => ['sh', '-c', 'true'],
+    }}
+    it {
+      should contain_file('/etc/consul/watch_my_watch.json') \
+          .with_content(/"args" *: *\[ *"sh", *"-c", *"true" *\]/) \
+          .with_content(/"type" *: *"nodes"/)
+    }
+  end
+
+  describe 'with both args and handler' do
+    let(:params) {{
+      'type' => 'nodes',
+      'handler' => 'handler_path',
+      'args' => ['sh', '-c', 'true'],
+    }}
+    it {
+      expect { should raise_error(Puppet::Error)}
+    }
+  end
+
   describe 'global attributes' do
     let (:params) {{
       'type' => 'nodes',


### PR DESCRIPTION
Similar to #400, but for the `consul::watch` resource. Adds support for the `args` parameter.