### PR TITLE
Set acces rights correctly

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,12 +13,16 @@ class consul::install {
       $binary_group = 'Administrators'
     }
     default: {
+      if ($consul::manage_group) and ($consul::install_method != 'docker' ) {
+        $binary_group = $consul::group_real
+      } else {
+        $binary_group = 0
+      }
       $binary_name = 'consul'
-      $binary_mode = '0555'
-      $data_dir_mode = '755'
+      $binary_mode = '0750'
+      $data_dir_mode = '0750'
       # 0 instead of root because OS X uses "wheel".
       $binary_owner = 'root'
-      $binary_group = 0
     }
   }
 


### PR DESCRIPTION
For security concerns it is better to set the access rights so that no other user can execute consul as it can give someone the possibility to join a cluster or issue a cli-command if http_and_cli is active

Also stated in this interesting article: https://www.mauras.ch/securing-consul.html