### PR TITLE
Support space-separated list in addresses

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -208,7 +208,7 @@ class consul (
   }
 
   if ($config_hash_real['addresses'] and $config_hash_real['addresses']['http']) {
-    $http_addr = $config_hash_real['addresses']['http']
+    $http_addr = split($config_hash_real['addresses']['http'], ' ')[0]
   } elsif ($config_hash_real['client_addr']) {
     $http_addr = $config_hash_real['client_addr']
   } else {


### PR DESCRIPTION
> In Consul 1.0 and later [addresses from config_hash] can be set to a space-separated list of addresses to bind to [...]

 https://www.consul.io/docs/agent/options.html#addresses

Using a space-separated list in addresses for 'http' is currently not supported because it would break config in init scripts and other places. Limiting this to the first one mentioned fixes this.