### PR TITLE
Add AArch64 (arm64) support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,7 @@ class consul::params {
   case $::architecture {
     'x86_64', 'x64', 'amd64': { $arch = 'amd64' }
     'i386':                   { $arch = '386'   }
+    'aarch64':                { $arch = 'arm64' }
     /^arm.*/:                 { $arch = 'arm'   }
     default:                  {
       fail("Unsupported kernel architecture: ${::architecture}")


### PR DESCRIPTION
This adds support for AArch64 which has official binaries named `arm64`, the value of `GOARCH`, currently only for Linux. (FreeBSD binaries are built for `arm` but not `arm64`.)

Unlike the large number of architecture variants referenced in #234, `aarch64` is the _only_ value of `architecture` on AArch64.