### PR TITLE
added install prefix to dirctory list to avoid puppet error when usin…

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,6 +30,7 @@ class consul::install {
 
       include archive
       file { [
+        $install_prefix,
         $install_path,
         "${install_path}/consul-${consul::version}"]:
         ensure => directory,


### PR DESCRIPTION
…g default data dir.

```
Error: Cannot create /opt/consul/archives; parent directory /opt/consul does not exist
Error: /Stage[main]/Consul::Install/File[/opt/consul/archives]/ensure: change from absent to directory failed: Cannot create /opt/consul/archives; parent directory /opt/consul does not exist
```