### PR TITLE
add support for the beta UI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ bundler_args: --without development --full-index
 before_install: rm Gemfile.lock || true
 sudo: false
 cache: bundler
-rvm:
-  - 2.1.9
-  - 2.4.2
 script: bundle exec rake test
-env:
-  - PUPPET_VERSION="~> 4.0"
-  - PUPPET_VERSION="~> 5.0"
+matrix:
+  fast_finish: true
+  include:
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.0"
+  - rvm: 2.4.3
+    env: PUPPET_VERSION="~> 5.0"
+  - rvm: 2.5.0
+    env: PUPPET_VERSION="~> 5.0"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,7 @@
 class consul::config(
   $config_hash,
   $purge = true,
+  $enable_beta_ui = $consul::enable_beta_ui,
 ) {
 
   if ($consul::init_style_real != 'unmanaged') {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,6 +136,8 @@
 #
 # [*shell*]
 #   The shell for the consul user. Defaults to something that prohibits login, like /usr/sbin/nologin
+# [*enable_beta_ui*]
+#   consul 1.1.0 introduced a new UI, which is currently (2018-05-12) in beta status. You can enable it by setting this variable to true. Defaults to false
 # === Examples
 #
 #  @example
@@ -192,6 +194,7 @@ class consul (
   $version                                   = $consul::params::version,
   Hash $watches                              = $consul::params::watches,
   Optional[String] $shell                    = $consul::params::shell,
+  Boolean $enable_beta_ui                    = false,
 ) inherits consul::params {
 
   # lint:ignore:140chars

--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -3,6 +3,9 @@ Description=Consul Agent
 After=network.target
 
 [Service]
+<% if @enable_beta_ui == true -%>
+Environment=CONSUL_UI_BETA=true
+<% end -%>
 User=<%= scope.lookupvar('consul::user') %>
 Group=<%= scope.lookupvar('consul::group') %>
 ExecStart=<%= scope.lookupvar('consul::bin_dir') %>/consul agent \


### PR DESCRIPTION
This PR adds an option to enable the new UI that is shipped with consul 1.1.0 https://www.consul.io/intro/getting-started/ui.html#how-to-use-the-new-ui