### PR TITLE
Change enableTagOverride to enable_tag_override in Consul 1.1.0 and later

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,7 +12,7 @@
 #   If provided an array of checks that will be added to this service
 #
 # [*enable_tag_override*]
-#   enableTagOverride support for service. Defaults to False.
+#   enable_tag_override support for service. Defaults to False.
 #
 # [*ensure*]
 #   Define availability of service. Use 'absent' to remove existing services.
@@ -48,6 +48,12 @@ define consul::service(
 
   consul_validate_checks($checks)
 
+  if versioncmp(getvar('::consul_version'), '1.1.0') >= 0 {
+    $override_key = 'enable_tag_override'
+  } else {
+    $override_key = 'enableTagOverride'
+  }
+
   $basic_hash = {
     'id'                => $id,
     'name'              => $service_name,
@@ -56,7 +62,7 @@ define consul::service(
     'tags'              => $tags,
     'checks'            => $checks,
     'token'             => $token,
-    'enableTagOverride' => $enable_tag_override,
+    $override_key       => $enable_tag_override,
   }
 
   $service_hash = {

--- a/spec/defines/consul_service_spec.rb
+++ b/spec/defines/consul_service_spec.rb
@@ -6,6 +6,17 @@ describe 'consul::service' do
 
   describe 'with no args' do
     let(:params) {{}}
+    it {
+      should contain_file("/etc/consul/service_my_service.json") \
+        .with_content(/"service" *: *\{/) \
+        .with_content(/"id" *: *"my_service"/) \
+        .with_content(/"name" *: *"my_service"/) \
+        .with_content(/"enable_tag_override" *: *false/)
+    }
+  end
+  describe 'with no args ( consul version less than 1.1.0 )' do
+    let(:params) {{}}
+    let(:facts) {{ :consul_version => '1.0.1' }}
 
     it {
       should contain_file("/etc/consul/service_my_service.json") \
@@ -52,7 +63,7 @@ describe 'consul::service' do
         .with_content(/"service" *: *\{/) \
         .with_content(/"id" *: *"my_service"/) \
         .with_content(/"name" *: *"my_service"/) \
-        .with_content(/"enableTagOverride" *: *true/)
+        .with_content(/"enable_tag_override" *: *true/)
     }
   end
   describe 'with service name and address' do


### PR DESCRIPTION
Consul 1.1.0 has dropped support for enableTagOverride. Use enable_tag_override instead.

see also: https://github.com/hashicorp/consul/blob/v1.1.0/CHANGELOG.md#110-may-11-2018