### PR TITLE
Use $consul::version instead of facter consul_version (Fix 09297fa)

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -48,7 +48,7 @@ define consul::service(
 
   consul_validate_checks($checks)
 
-  if versioncmp(getvar('::consul_version'), '1.1.0') >= 0 {
+  if versioncmp($consul::version, '1.1.0') >= 0 {
     $override_key = 'enable_tag_override'
   } else {
     $override_key = 'enableTagOverride'

--- a/spec/defines/consul_service_spec.rb
+++ b/spec/defines/consul_service_spec.rb
@@ -11,19 +11,20 @@ describe 'consul::service' do
         .with_content(/"service" *: *\{/) \
         .with_content(/"id" *: *"my_service"/) \
         .with_content(/"name" *: *"my_service"/) \
-        .with_content(/"enable_tag_override" *: *false/)
+        .with_content(/"enableTagOverride" *: *false/)
     }
   end
-  describe 'with no args ( consul version less than 1.1.0 )' do
-    let(:params) {{}}
-    let(:facts) {{ :consul_version => '1.0.1' }}
+  describe 'with no args ( consul version not less than 1.1.0 )' do
+    let(:pre_condition) {
+      'class { "consul": version => "1.1.0" }'
+    }
 
     it {
       should contain_file("/etc/consul/service_my_service.json") \
         .with_content(/"service" *: *\{/) \
         .with_content(/"id" *: *"my_service"/) \
         .with_content(/"name" *: *"my_service"/) \
-        .with_content(/"enableTagOverride" *: *false/)
+        .with_content(/"enable_tag_override" *: *false/)
     }
   end
   describe 'with different ensure' do
@@ -63,7 +64,7 @@ describe 'consul::service' do
         .with_content(/"service" *: *\{/) \
         .with_content(/"id" *: *"my_service"/) \
         .with_content(/"name" *: *"my_service"/) \
-        .with_content(/"enable_tag_override" *: *true/)
+        .with_content(/"enableTagOverride" *: *true/)
     }
   end
   describe 'with service name and address' do


### PR DESCRIPTION
Unless a host installed consul, facter `consul_version` returns undef and `versioncmp` raises evaluation error.

example:

> Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, 'versioncmp' parameter 'a' expects a String value, got Undef (file: /etc/puppetlabs/code/environments/ci/vendor/modules/consul/manifests/service.pp, line: 51, column: 6) (file: /etc/puppetlabs/code/environments/ci/vendor/modules/consul/manifests/init.pp, line: 238)