### PR TITLE
Annoying "defined 'protocol' as 'http'" for every consul_prepared_query resource

### DIFF
--- a/lib/puppet/provider/consul_prepared_query/default.rb
+++ b/lib/puppet/provider/consul_prepared_query/default.rb
@@ -31,8 +31,9 @@ Puppet::Type.type(:consul_prepared_query).provide(
   end
 
   def self.list_resources(acl_api_token, port, hostname, protocol, tries)
-    if @prepared_queries
-      return @prepared_queries
+    @prepared_queries ||= {}
+    if @prepared_queries[ "#{acl_api_token}#{port}#{hostname}#{protocol}#{tries}" ]
+      return @prepared_queries[ "#{acl_api_token}#{port}#{hostname}#{protocol}#{tries}" ]
     end
 
     # this might be configurable by searching /etc/consul.d
@@ -63,17 +64,18 @@ Puppet::Type.type(:consul_prepared_query).provide(
 
     nprepared_queries = prepared_queries.collect do |prepared_query|
       {
-        :name    => prepared_query["Name"],
-        :id      => prepared_query["ID"],
-        :session => prepared_query["Session"],
-        :token   => prepared_query["Token"],
-        :service => prepared_query["Service"],
-        :dns     => prepared_query["DNS"],
-        :ensure  => :present,
+        :name     => prepared_query["Name"],
+        :id       => prepared_query["ID"],
+        :session  => prepared_query["Session"],
+        :token    => prepared_query["Token"],
+        :service  => prepared_query["Service"],
+        :dns      => prepared_query["DNS"],
+        :protocol => protocol,
+        :ensure   => :present,
       }
     end
 
-    @prepared_queries = nprepared_queries
+    @prepared_queries[ "#{acl_api_token}#{port}#{hostname}#{protocol}#{tries}" ] = nprepared_queries
     nprepared_queries
   end
 

--- a/lib/puppet/type/consul_prepared_query.rb
+++ b/lib/puppet/type/consul_prepared_query.rb
@@ -91,8 +91,8 @@ Puppet::Type.newtype(:consul_prepared_query) do
 
   newproperty(:protocol) do
     desc 'consul protocol'
-    newvalues('http', 'https')
-    defaultto 'http'
+    newvalues(:http, :https)
+    defaultto :http
   end
 
   newparam(:port) do


### PR DESCRIPTION
Fix related to #410 
- added 'protocol' variable to the 'nprepared_queries'
- changes compatibile to the 'consul_acl' and 'consul_key_value'