### PR TITLE
Change "enableTagOverride" to "enable_tag_override" in version 1.0.0 and …

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -48,7 +48,7 @@ define consul::service(
 
   consul::validate_checks($checks)
 
-  if versioncmp($consul::version, '1.1.0') >= 0 {
+  if versioncmp($consul::version, '1.0.0') >= 0 {
     $override_key = 'enable_tag_override'
   } else {
     $override_key = 'enableTagOverride'


### PR DESCRIPTION
We are using Consul `1.0.0` and trying to upgrade to `1.3.0`, but we met this problem during the upgradation.

```
2018-10-23T19:38:51.089886-04:00 localhost puppet-user[13795]: (/Stage[main]/Consul::Install/Archive[/opt/consul/consul-1.3.0.zip]/ensure) download archive from https://releases.hashicorp.com/consul/1.3.0/consul_1.3.0_linux_amd64.zip to /opt/consul/consul-1.3.0.zip and extracted in /opt/consul/consul-1.3.0 with cleanup
2018-10-23T19:38:51.091618-04:00 localhost puppet-user[13795]: (/Stage[main]/Consul::Install/File[/opt/consul/consul-1.3.0/consul]/mode) mode changed '0755' to '0555'
2018-10-23T19:38:51.094394-04:00 localhost puppet-user[13795]: (/Stage[main]/Consul::Install/File[/usr/local/bin/consul]/target) target changed '/opt/consul/consul-1.0.0/consul' to '/opt/consul/consul-1.3.0/consul'
2018-10-23T19:38:52.573929-04:00 localhost consul[18317]:     2018/10/23 19:38:52 [INFO] Caught signal:  terminated
2018-10-23T19:38:52.574221-04:00 localhost consul[18317]:     2018/10/23 19:38:52 [INFO] Gracefully shutting down agent...
2018-10-23T19:38:52.574377-04:00 localhost consul[18317]:     2018/10/23 19:38:52 [INFO] consul: client starting leave
2018-10-23T19:38:53.272650-04:00 localhost consul[18317]:     2018/10/23 19:38:53 [INFO] serf: EventMemberLeave: i-01a1743299af60dee 10.6.50.245
2018-10-23T19:38:54.072957-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] Graceful exit completed
2018-10-23T19:38:54.073290-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] agent: Requesting shutdown
2018-10-23T19:38:54.073486-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] consul: shutting down client
2018-10-23T19:38:54.073662-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] manager: shutting down
2018-10-23T19:38:54.410053-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] agent: consul client down
2018-10-23T19:38:54.414516-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] agent: shutdown complete
2018-10-23T19:38:54.414637-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] agent: Stopping DNS server 127.0.0.1:8600 (tcp)
2018-10-23T19:38:54.414758-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] agent: Stopping DNS server 127.0.0.1:8600 (udp)
2018-10-23T19:38:54.414883-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] agent: Stopping HTTP server 127.0.0.1:8500 (tcp)
2018-10-23T19:38:54.911218-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] agent: Waiting for endpoints to shut down
2018-10-23T19:38:54.911435-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] agent: Endpoints down
2018-10-23T19:38:54.911612-04:00 localhost consul[18317]:     2018/10/23 19:38:54 [INFO] Exit code: 0
2018-10-23T19:38:54.934782-04:00 localhost puppet-user[13795]: (/Stage[main]/Consul::Run_service/Service[consul]) Triggered 'refresh' from 1 event
2018-10-23T19:38:54.998068-04:00 localhost consul[15507]: ==> Error parsing /etc/consul/service_gaf-exporter.json: 1 error(s) occurred:
2018-10-23T19:38:54.998294-04:00 localhost consul[15507]: * invalid config key service.enableTagOverride
```
Basically, because the current service config doesn't work in Consul version 1.3.0. so when puppet tries to restart the Consul service with 1.3.0 and it won't succeed.

I think instead replacing the deprecated fields when they are removed, it's better to replace them as soon as when they are deprecated.

> For Consul 0.9.3 and earlier you need to use enableTagOverride. Consul 1.0 supports both enable_tag_override and enableTagOverride but the latter is deprecated and has been removed as of Consul 1.1.

Since `1.0` is the version that supports both, I believe we should change `enableTagOverride` to `enable_tag_override` in `>=1.0.0`.