### PR TITLE
Restart only if config.json is chenged

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -105,6 +105,7 @@ class consul::config(
     group   => $consul::group_real,
     purge   => $purge,
     recurse => $purge,
+    notify  => Class['consul::reload_service'],
   }
   -> file { 'consul config.json':
     ensure  => present,
@@ -114,6 +115,7 @@ class consul::config(
     mode    => $::consul::config_mode,
     content => consul::sorted_json($config_hash, $::consul::pretty_config, $::consul::pretty_config_indent),
     require => File[$::consul::config_dir],
+    notify  => $notify_service,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -263,7 +263,6 @@ class consul (
   -> class { 'consul::config':
     config_hash => $config_hash_real,
     purge       => $purge_config_dir,
-    notify      => $notify_service,
   }
   -> class { 'consul::run_service': }
   -> class { 'consul::reload_service': }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -55,10 +55,6 @@ describe 'consul' do
         it { should contain_class('consul::config').with(purge: false) }
       end
 
-      context 'consul::config should notify consul::run_service' do
-        it { should contain_class('consul::config').that_notifies(['Class[consul::run_service]']) }
-      end
-
       context 'consul::config should not notify consul::run_service on config change' do
         let(:params) {{
           :restart_on_change => false


### PR DESCRIPTION
Restart only if config.json is changed. Removing service definition executes only service reload.

Signed-off-by: Martin Kolaci <martin.kolaci@lmc.eu>