### PR TITLE
Change allow for spaces in the path, Add extra_options to the win agent

### DIFF
--- a/manifests/windows_service.pp
+++ b/manifests/windows_service.pp
@@ -17,7 +17,7 @@ class consul::windows_service {
   $app_dir = regsubst($consul::bin_dir, '\/', '\\', 'G')
   $app_exec = "${app_dir}\\consul.exe"
   $agent_args = regsubst($consul::config_dir, '\/', '\\', 'G')
-  $app_args = "agent -config-dir=${agent_args}"
+  $app_args = "agent -config-dir='${agent_args}' ${consul::extra_options}"
   $app_log_path = "${app_dir}\\logs"
   $app_log_file = 'consul.log'
   $app_log = "${app_log_path}//${app_log_file}"
@@ -45,7 +45,7 @@ class consul::windows_service {
   }
   -> exec { 'consul_service_set_parameters':
     cwd         => $consul::bin_dir,
-    command     => "${consul::bin_dir}/set_service_parameters.ps1",
+    command     => "& '${consul::bin_dir}/set_service_parameters.ps1'",
     refreshonly => true,
     logoutput   => true,
     provider    => 'powershell',


### PR DESCRIPTION
When running with a path containing spaces the run fails. Surrounding the path in quotes and adding & to the front of the exec it now works.

I've also added the extra_options to the consul agent arguments so that additional parameters can be passed to the executable.  