### PR TITLE
add optional service meta hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,10 @@ configure a health check to monitor its availability.
     }
   ],
   port    => 6379,
-  tags    => ['master']
+  tags    => ['master'],
+  meta    => {
+    SLA => '1'
+  }
 }
 ```
 
@@ -142,6 +145,8 @@ consul::services:
     port: 42
     tags:
       - "foo:%{::bar}"
+    meta:
+      SLA: 1
   service2:
     address: "%{::ipaddress}"
     checks:
@@ -150,6 +155,8 @@ consul::services:
     port: 43
     tags:
       - "foo:%{::baz}"
+    meta:
+      SLA: 4
 ```
 
 ## Watch Definitions

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -61,17 +61,17 @@
 #  }
 #
 define consul::service(
-  $address                   = undef,
-  $checks                    = [],
-  $enable_tag_override       = false,
-  $ensure                    = present,
-  $id                        = $title,
-  $port                      = undef,
-  $service_name              = $title,
-  Hash $service_config_hash  = {},
-  $tags                      = [],
-  $token                     = undef,
-  Hash[String, String] $meta = {},
+  $address                         = undef,
+  $checks                          = [],
+  $enable_tag_override             = false,
+  $ensure                          = present,
+  $id                              = $title,
+  $port                            = undef,
+  $service_name                    = $title,
+  Hash $service_config_hash        = {},
+  $tags                            = [],
+  $token                           = undef,
+  Hash[String[1], String[1]] $meta = {},
 ) {
 
   include consul

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -36,6 +36,9 @@
 # [*token*]
 #   ACL token for interacting with the catalog (must be 'management' type)
 #
+# [*meta*]
+#   Service meta key/value pairs as hash.
+#
 # === Examples
 # @example
 #  consul::service { 'my_db':
@@ -58,16 +61,17 @@
 #  }
 #
 define consul::service(
-  $address                  = undef,
-  $checks                   = [],
-  $enable_tag_override      = false,
-  $ensure                   = present,
-  $id                       = $title,
-  $port                     = undef,
-  $service_name             = $title,
-  Hash $service_config_hash = {},
-  $tags                     = [],
-  $token                    = undef,
+  $address                   = undef,
+  $checks                    = [],
+  $enable_tag_override       = false,
+  $ensure                    = present,
+  $id                        = $title,
+  $port                      = undef,
+  $service_name              = $title,
+  Hash $service_config_hash  = {},
+  $tags                      = [],
+  $token                     = undef,
+  Hash[String, String] $meta = {},
 ) {
 
   include consul
@@ -88,6 +92,7 @@ define consul::service(
     'tags'              => $tags,
     'checks'            => $checks,
     'token'             => $token,
+    'meta'              => $meta,
     $override_key       => $enable_tag_override,
   }
 

--- a/spec/defines/consul_service_spec.rb
+++ b/spec/defines/consul_service_spec.rb
@@ -14,6 +14,7 @@ describe 'consul::service' do
         it {
           should contain_file("/etc/consul/service_my_service.json") \
             .with_content(/"service" *: *\{/) \
+            .with_content(/"meta" *: *\{\}/) \
             .with_content(/"id" *: *"my_service"/) \
             .with_content(/"name" *: *"my_service"/) \
             .with_content(/"enable_tag_override" *: *false/)
@@ -27,6 +28,7 @@ describe 'consul::service' do
         it {
           should contain_file("/etc/consul/service_my_service.json") \
             .with_content(/"service" *: *\{/) \
+            .with_content(/"meta" *: *\{\}/) \
             .with_content(/"id" *: *"my_service"/) \
             .with_content(/"name" *: *"my_service"/) \
             .with_content(/"enable_tag_override" *: *false/)
@@ -259,6 +261,19 @@ describe 'consul::service' do
         it {
           should contain_file("/etc/consul/service_my_service.json") \
             .with_content(/"token" *: *"too-cool-for-this-service"/)
+        }
+      end
+      describe 'with meta' do
+        let(:params) {{
+          'meta' => {
+            'foo' => 'bar',
+          },
+        }}
+
+        it {
+          should contain_file("/etc/consul/service_my_service.json") \
+            .with_content(/"meta" *: *\{/) \
+            .with_content(/"foo" *: *"bar"/)
         }
       end
     end


### PR DESCRIPTION
Hi,

as requested in #436 and similar to #441 this is an up-to-date PR based on latest master of solarkennedy and the work of sc0rp10.
It adds meta hash the a service definition. The hash is optional.

Note: I've not clue about the spec files. Just took over the changes initially made. Will need external input if something is broken there.

Best regards

jardleex