### PR TITLE
Don't write out meta parameter when unset

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -71,7 +71,7 @@ define consul::service(
   Hash $service_config_hash        = {},
   $tags                            = [],
   $token                           = undef,
-  Hash[String[1], String[1]] $meta = {},
+  Hash[String[1], String[1]] $meta = undef,
 ) {
 
   include consul

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -61,17 +61,17 @@
 #  }
 #
 define consul::service(
-  $address                         = undef,
-  $checks                          = [],
-  $enable_tag_override             = false,
-  $ensure                          = present,
-  $id                              = $title,
-  $port                            = undef,
-  $service_name                    = $title,
-  Hash $service_config_hash        = {},
-  $tags                            = [],
-  $token                           = undef,
-  Hash[String[1], String[1]] $meta = undef,
+  $address                                   = undef,
+  $checks                                    = [],
+  $enable_tag_override                       = false,
+  $ensure                                    = present,
+  $id                                        = $title,
+  $port                                      = undef,
+  $service_name                              = $title,
+  Hash $service_config_hash                  = {},
+  $tags                                      = [],
+  $token                                     = undef,
+  Optional[Hash[String[1], String[1]]] $meta = undef,
 ) {
 
   include consul

--- a/spec/defines/consul_service_spec.rb
+++ b/spec/defines/consul_service_spec.rb
@@ -14,7 +14,6 @@ describe 'consul::service' do
         it {
           should contain_file("/etc/consul/service_my_service.json") \
             .with_content(/"service" *: *\{/) \
-            .with_content(/"meta" *: *\{\}/) \
             .with_content(/"id" *: *"my_service"/) \
             .with_content(/"name" *: *"my_service"/) \
             .with_content(/"enable_tag_override" *: *false/)
@@ -28,7 +27,6 @@ describe 'consul::service' do
         it {
           should contain_file("/etc/consul/service_my_service.json") \
             .with_content(/"service" *: *\{/) \
-            .with_content(/"meta" *: *\{\}/) \
             .with_content(/"id" *: *"my_service"/) \
             .with_content(/"name" *: *"my_service"/) \
             .with_content(/"enable_tag_override" *: *false/)


### PR DESCRIPTION
For versions of Consul < 1.1.0, setting `"meta": {}` in the service config doesn't work, because Consul doesn't know about the key. This sets it to `undef` so that there won't be a meta hash with no keys written out when unspecified.