### PR TITLE
fix case where multiple http_addr

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -235,7 +235,7 @@ class consul (
   if ($config_hash_real['addresses'] and $config_hash_real['addresses']['http']) {
     $http_addr = split($config_hash_real['addresses']['http'], ' ')[0]
   } elsif ($config_hash_real['client_addr']) {
-    $http_addr = $config_hash_real['client_addr']
+    $http_addr = split($config_hash_real['client_addr'], ' ')[0]
   } else {
     $http_addr = $::ipaddress_lo
   }


### PR DESCRIPTION
with patch applied...

Notice: /Stage[main]/Consul::Config/File[/etc/init.d/consul]/content: 
--- /etc/init.d/consul	2019-01-30 11:59:11.133195366 -0800
+++ /tmp/puppet-file20190213-127228-1atiisu	2019-02-13 10:57:09.024947000 -0800
@@ -17,7 +17,7 @@
 CONFIG=/etc/consul
 PID_FILE=/var/run/consul/consul.pid
 LOG_FILE=/var/log/consul
-HTTP_ADDR=-http-addr=127.0.0.1 10.1.2.3:8500
+HTTP_ADDR=-http-addr=127.0.0.1:8500
 
 [ -e /etc/sysconfig/consul ] && . /etc/sysconfig/consul