### PR TITLE
quote all values of tags, meta & node_meta

### DIFF
--- a/lib/puppet/functions/consul/sorted_json.rb
+++ b/lib/puppet/functions/consul/sorted_json.rb
@@ -56,7 +56,7 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
   #         ]
   #     }
   #
-  def sorted_json(unsorted_hash = {}, pretty = false, indent_len = 4, quoted=false)
+  def sorted_json(unsorted_hash = {}, pretty = false, indent_len = 4)
     # simplify jsonification of standard types
     simple_generate = lambda do |obj|
       case obj
@@ -66,8 +66,8 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
           "#{obj}"
         else
           # Should be a string
-          # keep string integers unquoted when quoted == false
-          (obj =~ /\A[-]?(0|[1-9]\d*)\z/ && !quoted) ? obj : obj.to_json
+          # keep string integers unquoted
+          (obj =~ /\A[-]?(0|[1-9]\d*)\z/) ? obj : obj.to_json
       end
     end
 
@@ -84,10 +84,7 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
         when Hash
           ret = []
           obj.keys.sort.each do |k|
-            if k =~ /\A(node_meta|tags)\z/ then
-              quoted = true
-            end
-            ret.push(k.to_json << ":" << sorted_generate.call(obj[k], quoted))
+            ret.push(k.to_json << ":" << sorted_generate.call(obj[k]))
           end
           return "{" << ret.join(",") << "}";
         else
@@ -130,9 +127,6 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
           # This level works in a similar way to the above
           level += 1
           obj.keys.sort.each do |k|
-            if k =~ /\A(node_meta|tags)\z/ then
-              quoted = true
-            end
             ret.push("#{indent * level}" << k.to_json << ": " << sorted_pretty_generate.call(obj[k], indent_len, level))
           end
           level -= 1

--- a/lib/puppet/functions/consul/sorted_json.rb
+++ b/lib/puppet/functions/consul/sorted_json.rb
@@ -56,7 +56,7 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
   #         ]
   #     }
   #
-  def sorted_json(unsorted_hash = {}, pretty = false, indent_len = 4)
+  def sorted_json(unsorted_hash = {}, pretty = false, indent_len = 4, quoted=false)
     # simplify jsonification of standard types
     simple_generate = lambda do |obj|
       case obj
@@ -66,8 +66,8 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
           "#{obj}"
         else
           # Should be a string
-          # keep string integers unquoted
-          (obj =~ /\A[-]?(0|[1-9]\d*)\z/) ? obj : obj.to_json
+          # keep string integers unquoted when quoted == false
+          (obj =~ /\A[-]?(0|[1-9]\d*)\z/ && !quoted) ? obj : obj.to_json
       end
     end
 
@@ -84,7 +84,10 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
         when Hash
           ret = []
           obj.keys.sort.each do |k|
-            ret.push(k.to_json << ":" << sorted_generate.call(obj[k]))
+            if k =~ /\A(node_meta|tags)\z/ then
+              quoted = true
+            end
+            ret.push(k.to_json << ":" << sorted_generate.call(obj[k], quoted))
           end
           return "{" << ret.join(",") << "}";
         else
@@ -127,6 +130,9 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
           # This level works in a similar way to the above
           level += 1
           obj.keys.sort.each do |k|
+            if k =~ /\A(node_meta|tags)\z/ then
+              quoted = true
+            end
             ret.push("#{indent * level}" << k.to_json << ": " << sorted_pretty_generate.call(obj[k], indent_len, level))
           end
           level -= 1

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -71,7 +71,11 @@ define consul::service(
   Hash $service_config_hash                  = {},
   $tags                                      = [],
   $token                                     = undef,
-  Optional[Hash[String[1], String[1]]] $meta = undef,
+  Optional[Hash[
+    String[1],
+    Variant[
+      String[1], Numeric, Boolean
+  ]]]                                  $meta = undef,
 ) {
 
   include consul

--- a/spec/functions/consul_sorted_json_spec.rb
+++ b/spec/functions/consul_sorted_json_spec.rb
@@ -48,6 +48,15 @@ RSpec.shared_examples 'handling_simple_types' do |pretty|
   it 'handles simple string' do
     is_expected.to run.with_params({'key' => 'aString' },pretty).and_return(deprettyfy("{\n    \"key\": \"aString\"\n}\n",pretty))
   end
+  it 'quotes values of tags' do
+    is_expected.to run.with_params({'tags' => 12 },pretty).and_return(deprettyfy("{\n    \"tags\": \"12\"\n}\n",pretty))
+  end
+  it 'quotes values of meta' do
+    is_expected.to run.with_params({'meta' => {'sla' => 2 } },pretty).and_return(deprettyfy("{\n    \"meta\": {\n        \"sla\": \"2\"\n    }\n}\n",pretty))
+  end
+  it 'quotes values of node_meta' do
+    is_expected.to run.with_params({'node_meta' => {'cpus' => 8 } },pretty).and_return(deprettyfy("{\n    \"node_meta\": {\n        \"cpus\": \"8\"\n    }\n}\n",pretty))
+  end
 end
 describe 'consul::sorted_json', :type => :puppet_function do
 


### PR DESCRIPTION
Values of tags, meta and node_meta needs always to be quoted.

This fixes #318, fixes #468, fixes #283 and closes #436.