### PR TITLE
Switch from anchor pattern to contain function

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,12 +19,12 @@
 # [*restart_on_change*]
 #   Bool. Should the service be restarted on changes
 #
-class consul::config(
-  Hash $config_hash,
-  Boolean $purge = true,
-  Boolean $enable_beta_ui = $consul::enable_beta_ui,
+class consul::config (
+  Hash    $config_hash                 = $consul::config_hash_real,
+  Boolean $purge                       = $consul::purge_config_dir,
+  Boolean $enable_beta_ui              = $consul::enable_beta_ui,
   Boolean $allow_binding_to_root_ports = $consul::allow_binding_to_root_ports,
-  Boolean $restart_on_change = $consul::restart_on_change,
+  Boolean $restart_on_change           = $consul::restart_on_change,
 ) {
 
   $notify_service = $restart_on_change ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -256,19 +256,19 @@ class consul (
     create_resources(consul_acl, $acls)
   }
 
-  $notify_service = $restart_on_change ? {
-    true    => Class['consul::run_service'],
-    default => undef,
+  contain 'consul::install'
+  contain 'consul::config'
+  contain 'consul::run_service'
+  contain 'consul::reload_service'
+
+  Class['consul::install']
+  -> Class['consul::config']
+  -> Class['consul::run_service']
+  -> Class['consul::reload_service']
+
+  if $restart_on_change {
+    Class['consul::config']
+    ~> Class['consul::run_service']
   }
 
-  anchor {'consul_first': }
-  -> class { 'consul::install': }
-  -> class { 'consul::config':
-    config_hash => $config_hash_real,
-    purge       => $purge_config_dir,
-    notify      => $notify_service,
-  }
-  -> class { 'consul::run_service': }
-  -> class { 'consul::reload_service': }
-  -> anchor {'consul_last': }
 }


### PR DESCRIPTION
The `contain` function is preferred over the anchor pattern when on Puppet 4+.

This also:
* Removes the resource-like declaration of the sub classes which makes the code a bit more portable.
* Accounts for the `$consul::notify_service` variable not existing anymore in `init.pp`