### PR TITLE
Remove the id=title variable, make event_name=title

### DIFF
--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -13,7 +13,7 @@
 #   Defaults to 'present'
 #
 # [*event_name*]
-#   Name of an event to watch for.
+#   Name of an event to watch for, defaults to the resource title.
 #
 # [*handler*]
 #   Full path to the script that will be excuted. This parameter is deprecated
@@ -51,7 +51,7 @@ define consul::watch (
   $args                          = undef,
   $datacenter                    = undef,
   $ensure                        = present,
-  $event_name                    = undef,
+  $event_name                    = $title,
   $handler                       = undef,
   $key                           = undef,
   $keyprefix                     = undef,
@@ -64,7 +64,6 @@ define consul::watch (
 ) {
 
   include consul
-  $id = $title
 
   $basic_hash = {
     'type'       => $type,
@@ -140,7 +139,7 @@ define consul::watch (
     watches => [delete_undef_values(merge($basic_hash, $type_hash))],
   }
 
-  file { "${consul::config_dir}/watch_${id}.json":
+  file { "${consul::config_dir}/watch_${event_name}.json":
     ensure  => $ensure,
     owner   => $consul::user_real,
     group   => $consul::group_real,

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -5,6 +5,9 @@
 #
 # == Parameters
 #
+# [*config_filename*]
+#   Enables backwards compatiblity, and allows you to override the name of the config file.
+#
 # [*datacenter*]
 #   String overriding consul's default datacenter.
 #
@@ -49,6 +52,7 @@
 #
 define consul::watch (
   $args                          = undef,
+  $config_filename               = "watch_${title}.json",
   $datacenter                    = undef,
   $ensure                        = present,
   $event_name                    = $title,
@@ -139,7 +143,7 @@ define consul::watch (
     watches => [delete_undef_values(merge($basic_hash, $type_hash))],
   }
 
-  file { "${consul::config_dir}/watch_${event_name}.json":
+  file { "${consul::config_dir}/${config_filename}":
     ensure  => $ensure,
     owner   => $consul::user_real,
     group   => $consul::group_real,


### PR DESCRIPTION
Otherwise, when creating a watch event, nameless events are easily created.