### PR TITLE
resources 'acl' and 'operator' don't have a segment

### DIFF
--- a/lib/puppet/provider/consul_policy/default.rb
+++ b/lib/puppet/provider/consul_policy/default.rb
@@ -43,7 +43,11 @@ Puppet::Type.type(:consul_policy).provide(
     encoded = []
 
     rules.each do |rule|
-      encoded.push("#{rule['resource']} \"#{rule['segment']}\" {\n  policy = \"#{rule['disposition']}\"\n}")
+      if ['acl', 'operator'].include?(rule['resource'])
+        encoded.push("#{rule['resource']} = \"#{rule['disposition']}\"")
+      else
+        encoded.push("#{rule['resource']} \"#{rule['segment']}\" {\n  policy = \"#{rule['disposition']}\"\n}")
+      end
     end
 
     encoded.join("\n\n")

--- a/lib/puppet/type/consul_policy.rb
+++ b/lib/puppet/type/consul_policy.rb
@@ -34,11 +34,11 @@ Puppet::Type.newtype(:consul_policy) do
       raise ArgumentError, "Policy rule must be a hash" unless value.is_a?(Hash)
 
       raise ArgumentError, "Policy rule needs to specify a resource" unless value.key?('resource')
-      raise ArgumentError, "Policy rule needs to specify a segment" unless value.key?('segment')
+      raise ArgumentError, "Policy rule needs to specify a segment" unless value.key?('segment') || ['acl', 'operator'].include?(value['resource'])
       raise ArgumentError, "Policy rule needs to specify a disposition" unless value.key?('disposition')
 
       raise ArgumentError, "Policy rule resource must be a string" unless value['resource'].is_a?(String)
-      raise ArgumentError, "Policy rule segment must be a string" unless value['segment'].is_a?(String)
+      raise ArgumentError, "Policy rule segment must be a string" unless value['segment'].is_a?(String) || ['acl', 'operator'].include?(value['resource'])
       raise ArgumentError, "Policy rule disposition must be a string" unless value['disposition'].is_a?(String)
     end
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -202,6 +202,7 @@ describe 'consul class' do
                 {'resource' => 'service_prefix', 'segment' => 'tst_service', 'disposition' => 'read'},
                 {'resource' => 'key', 'segment' => 'test_key', 'disposition' => 'write'},
                 {'resource' => 'node_prefix', 'segment' => '', 'disposition' => 'deny'},
+                {'resource' => 'operator', 'disposition' => 'read'},
               ],
             },
             'test_policy_absent' => {

--- a/spec/unit/puppet/type/consul_policy_spec.rb
+++ b/spec/unit/puppet/type/consul_policy_spec.rb
@@ -47,22 +47,6 @@ describe Puppet::Type.type(:consul_policy) do
     end.to raise_error(Puppet::Error, /Policy rule needs to specify a resource/)
   end
 
-  it 'should fail if rule segment is missing' do
-    expect do
-      Puppet::Type.type(:consul_policy).new(
-          :name         => 'testing',
-          :id           => '39c75e12-7f43-0a40-dfba-9aa3fcda08d4',
-          :description  => 'test description',
-          :rules        => [
-              {
-                  'resource'    =>  'service_prefix',
-                  'disposition' => 'read'
-              }
-          ]
-      )
-    end.to raise_error(Puppet::Error, /Policy rule needs to specify a segment/)
-  end
-
   it 'should fail if rule disposition is missing' do
     expect do
       Puppet::Type.type(:consul_policy).new(
@@ -96,23 +80,6 @@ describe Puppet::Type.type(:consul_policy) do
     end.to raise_error(Puppet::Error, /Policy rule resource must be a string/)
   end
 
-  it 'should fail if rule segment is not a string' do
-    expect do
-      Puppet::Type.type(:consul_policy).new(
-          :name         => 'testing',
-          :id           => '39c75e12-7f43-0a40-dfba-9aa3fcda08d4',
-          :description  => 'test description',
-          :rules        => [
-              {
-                  'resource'    => 'key_prefix',
-                  'segment'     => [],
-                  'disposition' => 'read'
-              }
-          ]
-      )
-    end.to raise_error(Puppet::Error, /Policy rule segment must be a string/)
-  end
-
   it 'should fail if rule disposition is not a string' do
     expect do
       Puppet::Type.type(:consul_policy).new(
@@ -128,6 +95,87 @@ describe Puppet::Type.type(:consul_policy) do
           ]
       )
     end.to raise_error(Puppet::Error, /Policy rule disposition must be a string/)
+  end
+
+  context 'resource is acl or operator' do
+    it 'should pass if rule segment is missing' do
+      expect do
+        Puppet::Type.type(:consul_policy).new(
+            :name         => 'testing',
+            :id           => '39c75e12-7f43-0a40-dfba-9aa3fcda08d4',
+            :description  => 'test description',
+            :rules        => [
+                {
+                    'resource'    => 'acl',
+                    'disposition' => 'read'
+                }
+            ]
+        )
+        Puppet::Type.type(:consul_policy).new(
+          :name         => 'testing',
+          :id           => '39c75e12-7f43-0a40-dfba-9aa3fcda08d4',
+          :description  => 'test description',
+          :rules        => [
+              {
+                  'resource'    => 'operator',
+                  'disposition' => 'read'
+              }
+          ]
+        )
+      end.not_to raise_error
+    end
+
+    it 'should pass if rule segment is not a string' do
+      expect do
+        Puppet::Type.type(:consul_policy).new(
+            :name         => 'testing',
+            :id           => '39c75e12-7f43-0a40-dfba-9aa3fcda08d4',
+            :description  => 'test description',
+            :rules        => [
+                {
+                    'resource'    => 'operator',
+                    'segment'     => [],
+                    'disposition' => 'read'
+                }
+            ]
+        )
+      end.not_to raise_error
+    end
+  end
+
+  context 'resource is neither acl nor operator' do
+    it 'should fail if rule segment is missing' do
+      expect do
+        Puppet::Type.type(:consul_policy).new(
+            :name         => 'testing',
+            :id           => '39c75e12-7f43-0a40-dfba-9aa3fcda08d4',
+            :description  => 'test description',
+            :rules        => [
+                {
+                    'resource'    => 'service_prefix',
+                    'disposition' => 'read'
+                }
+            ]
+        )
+      end.to raise_error(Puppet::Error, /Policy rule needs to specify a segment/)
+    end
+
+    it 'should fail if rule segment is not a string' do
+      expect do
+        Puppet::Type.type(:consul_policy).new(
+            :name         => 'testing',
+            :id           => '39c75e12-7f43-0a40-dfba-9aa3fcda08d4',
+            :description  => 'test description',
+            :rules        => [
+                {
+                    'resource'    => 'key_prefix',
+                    'segment'     => [],
+                    'disposition' => 'read'
+                }
+            ]
+        )
+      end.to raise_error(Puppet::Error, /Policy rule segment must be a string/)
+    end
   end
 
   context 'with name defined' do

--- a/types/policystruct.pp
+++ b/types/policystruct.pp
@@ -4,7 +4,7 @@ type Consul::PolicyStruct = Struct[{
   description   => Optional[String[0]],
   rules         => Optional[Array[Struct[{
     resource    => String[1],
-    segment     => String[0],
+    segment     => Optional[String[0]],
     disposition => String[1],
   }]]],
   acl_api_token => Optional[String[1]],


### PR DESCRIPTION
The special policies `acl` and `operator` don't have a `segment` option.
This PR adds support for them.

Fixes #482 