### PR TITLE
Add a sleep between tries of consul service reload

### DIFF
--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -42,6 +42,7 @@ class consul::reload_service {
       command     => $command,
       refreshonly => true,
       tries       => 3,
+      try_sleep   => 10,
     }
   }
 }


### PR DESCRIPTION
As expressed issue #231, consul reload will fails if it happens while consul is still booting. However, the addition of multiple tries does not solve the issue as all tries can occur in a very short lapse of time.

In this PR, we introduce a sleep between each try, leaving consul up to 20 seconds between the first and the last reload to complete its boot, which should be enough.