### PR TITLE
Bump upper version range for puppetlabs/stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.13.1 < 7.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
Current stdlib version is 6.1.0 so it's good idea to bump upper version range to 7.0.0