### PR TITLE
added support for reload over https

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -277,7 +277,7 @@ class consul (
   if dig($config_hash_real,'verify_incoming') {
     $verify_incoming = $config_hash_real['verify_incoming']
   } else {
-    $verify_incoming = False
+    $verify_incoming = false
   }
 
   if dig($config_hash_real,'cert_file') {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -260,12 +260,36 @@ class consul (
     $http_port = 8500
   }
 
+  if dig($config_hash_real,'ports','https') {
+    $https_port = $config_hash_real['ports']['https']
+  } else {
+    $https_port = Undef
+  }
+
   if dig($config_hash_real,'addresses','http') {
     $http_addr = split($config_hash_real['addresses']['http'], ' ')[0]
   } elsif ($config_hash_real['client_addr']) {
     $http_addr = split($config_hash_real['client_addr'], ' ')[0]
   } else {
     $http_addr = '127.0.0.1'
+  }
+
+  if dig($config_hash_real,'verify_incoming') {
+    $verify_incoming = $config_hash_real['verify_incoming']
+  } else {
+    $verify_incoming = False
+  }
+
+  if dig($config_hash_real,'cert_file') {
+    $cert_file = $config_hash_real['cert_file']
+  } else {
+    $cert_file = Undef
+  }
+
+  if dig($config_hash_real,'key_file') {
+    $key_file = $config_hash_real['key_file']
+  } else {
+    $key_file = Undef
   }
 
   if $services {

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -20,7 +20,7 @@ class consul::reload_service {
     }
 
     # The reload service should connect to http if possible (http port different from -1)
-    if $consul::http_port != '-1' {
+    if $consul::http_port != -1 {
       $reload_options = "-http-addr=${http_addr}:${consul::http_port}"
     }
     elsif $consul::verify_incoming  { # in case incoming connections are verified correct certificate files should be used

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -24,10 +24,10 @@ class consul::reload_service {
       $reload_options = "-http-addr=${http_addr}:${consul::http_port}"
     }
     elsif $consul::verify_incoming  { # in case incoming connections are verified correct certificate files should be used
-      $reload_options = "-http-addr=https://$(hostname):${consul::https_port} -client-cert=${consul::cert_file} -client-key=${consul::key_file}"
+      $reload_options = "-http-addr=https://localhost:${consul::https_port} -client-cert=${consul::cert_file} -client-key=${consul::key_file}"
     }
     else {
-      $reload_options = "-http-addr=https://$(hostname):${consul::https_port}}"
+      $reload_options = "-http-addr=https://localhost:${consul::https_port}}"
     }
 
 
@@ -38,6 +38,7 @@ class consul::reload_service {
 
     exec { 'reload consul service':
       path        => [$consul::bin_dir,'/bin','/usr/bin'],
+      environment => [ 'CONSUL_HTTP_SSL_VERIFY=false',],
       command     => $command,
       refreshonly => true,
       tries       => 3,

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -20,7 +20,7 @@ class consul::reload_service {
     }
 
     # The reload service should connect to http if possible (http port different from -1)
-    if $consul::http_port != "-1" {
+    if $consul::http_port != '-1' {
       $reload_options = "-http-addr=${http_addr}:${consul::http_port}"
     }
     elsif $consul::verify_incoming  { # in case incoming connections are verified correct certificate files should be used
@@ -28,12 +28,12 @@ class consul::reload_service {
     }
     else {
       $reload_options = "-http-addr=https://$(hostname):${consul::https_port}}"
-   }
+    }
 
 
     case $consul::install_method {
-      'docker': { $command = "docker exec consul consul reload  $reload_options"}
-      default: { $command = "consul reload $reload_options"}
+      'docker': { $command = "docker exec consul consul reload  ${reload_options}"}
+      default: { $command = "consul reload ${reload_options}"}
     }
 
     exec { 'reload consul service':

--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -19,9 +19,21 @@ class consul::reload_service {
       $http_addr = $consul::http_addr
     }
 
+    # The reload service should connect to http if possible (http port different from -1)
+    if $consul::http_port != "-1" {
+      $reload_options = "-http-addr=${http_addr}:${consul::http_port}"
+    }
+    elsif $consul::verify_incoming  { # in case incoming connections are verified correct certificate files should be used
+      $reload_options = "-http-addr=https://$(hostname):${consul::https_port} -client-cert=${consul::cert_file} -client-key=${consul::key_file}"
+    }
+    else {
+      $reload_options = "-http-addr=https://$(hostname):${consul::https_port}}"
+   }
+
+
     case $consul::install_method {
-      'docker': { $command = "docker exec consul consul reload -http-addr=${http_addr}:${consul::http_port}" }
-      default: { $command = "consul reload -http-addr=${http_addr}:${consul::http_port}" }
+      'docker': { $command = "docker exec consul consul reload  $reload_options"}
+      default: { $command = "consul reload $reload_options"}
     }
 
     exec { 'reload consul service':


### PR DESCRIPTION
# Why?
When adding a service, or performing other change which requires consul to reload, consul is reloaded with the command:
```
consul reload -http-addr=127.0.0.1:8500 (with address and port configurable)
```
However this assumes that consul allows connections via http, without encryption or identity verification. 

For sensitive productions scenarios however, consul should only allow mutual tls connections. In this case the reloading will fail, as it tries to connect over http without valid certificate.

This merge request will allow the reload to happen over TLS, with the correct certificates.

# How does it work?
If the http port is disabled (equal to -1) and `verify_incoming` is set to true in the consul configuration, the reload will now happen automatically over TLS with the correct certificates.