### PR TITLE
drop puppetlabs/powershell dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ new versions of consul. Pin to the version that works for your setup!
 * Installs the consul daemon (via url or package)
   * If installing from zip, you *must* ensure the unzip utility is available.
   * If installing from docker, you *must* ensure puppetlabs-docker_platform module is available.
+  * If installing on windows, you *must* install the `puppetlabs/powershell` module.
 * Optionally installs a user to run it under
 * Installs a configuration file (/etc/consul/config.json)
 * Manages the consul service via upstart, sysv, systemd, or nssm.

--- a/metadata.json
+++ b/metadata.json
@@ -19,10 +19,6 @@
     {
       "name": "camptocamp/systemd",
       "version_requirement": ">= 1.1.1 < 3.0.0"
-    },
-    {
-      "name": "puppetlabs/powershell",
-      "version_requirement": ">= 2.1.3 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The dependency is rarely needed so it's a soft-dependency and should not be included within the metadata.json.