### PR TITLE
systemd: Start consul after network is really up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /spec/fixtures/modules/
 /tmp/
 /vendor/
+/.vendor/
 /convert_report.txt
 /update_report.txt
 .DS_Store

--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -1,7 +1,8 @@
 # THIS FILE IS MANAGED BY PUPPET
 [Unit]
 Description=Consul Agent
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 <% if @allow_binding_to_root_ports == true -%>


### PR DESCRIPTION
This change is based on systemd documentation from:
https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
The network-online.target is reached after an actual ip configuration is up. This is required if consul should bind to a specific ip address.