### PR TITLE
Move consul unit file to /usr/lib/systemd/system, as we install consul like it was packaged

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,6 +54,7 @@ class consul::config (
       'systemd': {
         systemd::unit_file { 'consul.service':
           content => template('consul/consul.systemd.erb'),
+          path    => '/usr/lib/systemd/system',
           notify  => $notify_service,
         }
       }


### PR DESCRIPTION
`/etc/systemd/system` is a place for hand-crafted unit files and overrides units from `/usr/lib/systemd/system`.

Creating overrides or drop-ins is impossible, because puppet overwrites such file.