### PR TITLE
sorted_json should quote args for checks regardless of data type

### DIFF
--- a/lib/puppet/functions/consul/sorted_json.rb
+++ b/lib/puppet/functions/consul/sorted_json.rb
@@ -89,7 +89,7 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
         when Hash
           ret = []
           obj.keys.sort.each do |k|
-            if k =~ /\A(node_meta|meta|tags)\z/ then
+            if k =~ /\A(node_meta|meta|tags|args)\z/ then
               quoted = true
             elsif k =~ /\A(weights)\z/ then
               quoted = false
@@ -138,7 +138,7 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
           # This level works in a similar way to the above
           level += 1
           obj.keys.sort.each do |k|
-            if k =~ /\A(node_meta|meta|tags)\z/ then
+            if k =~ /\A(node_meta|meta|tags|args)\z/ then
               quoted = true
             elsif k =~ /\A(weights)\z/ then
               quoted = false

--- a/spec/defines/consul_check_spec.rb
+++ b/spec/defines/consul_check_spec.rb
@@ -7,7 +7,7 @@ describe 'consul::check' do
       let :facts do
         facts
       end
-  
+
       let(:title) { "my_check" }
 
       describe 'with no args' do
@@ -36,7 +36,7 @@ describe 'consul::check' do
       describe 'with args' do
         let(:params) {{
           'interval' => '30s',
-          'args'     => ['sh', '-c', 'true'],
+          'args'     => ['sh', '-c', 'true', '1', 2],
         }}
         it {
           should contain_file("/etc/consul/check_my_check.json") \
@@ -44,7 +44,7 @@ describe 'consul::check' do
             .with_content(/"name" *: *"my_check"/) \
             .with_content(/"check" *: *\{/) \
             .with_content(/"interval" *: *"30s"/) \
-            .with_content(/"args" *: *\[ *"sh", *"-c", *"true" *\]/)
+            .with_content(/"args" *: *\[ *"sh", *"-c", *"true", *"1", *"2" *\]/)
         }
       end
       describe 'with script and service_id' do

--- a/spec/defines/consul_service_spec.rb
+++ b/spec/defines/consul_service_spec.rb
@@ -172,7 +172,7 @@ describe 'consul::service' do
               'passing' => 10,
               'warning' => 1
             }
-          }      
+          }
         }}
         it {
           should contain_file("/etc/consul/service_my_service.json") \

--- a/spec/functions/consul_sorted_json_spec.rb
+++ b/spec/functions/consul_sorted_json_spec.rb
@@ -57,6 +57,9 @@ RSpec.shared_examples 'handling_simple_types' do |pretty|
   it 'quotes values of node_meta' do
     is_expected.to run.with_params({'node_meta' => {'cpus' => 8 } },pretty).and_return(deprettyfy("{\n    \"node_meta\": {\n        \"cpus\": \"8\"\n    }\n}\n",pretty))
   end
+  it 'quotes values of args' do
+    is_expected.to run.with_params({'args' => ['aString', '1', 2] },pretty).and_return(deprettyfy("{\n    \"args\": [\n        \"aString\",\n        \"1\",\n        \"2\"\n    ]\n}\n",pretty))
+  end
 end
 describe 'consul::sorted_json', :type => :puppet_function do
 


### PR DESCRIPTION
Similar to #473, all arguments passed as `args` to a Consul check should be quoted, including integers.

Currently, we write out a service/check definition as follows:

```json
{
  "service": {
    "address": "127.0.0.1",
    "checks": [
      {
        "args": [
          "/bin/true",
          1
        ],
        "interval": "10s"
      }
    ],
    ...
```

Consul throws something like this this:

```
Dec 16 00:24:24 instance-1 consul[1848]: ==> Error parsing /etc/consul/service_my-service.json: 2 error(s) decoding:
Dec 16 00:24:24 instance-1 consul[1848]: * 'service.checks[0].args[4]' expected type 'string', got unconvertible type 'float64'
Dec 16 00:24:24 instance-1 consul[1848]: * 'service.checks[0].args[6]' expected type 'string', got unconvertible type 'float64'
```

This change quotes whatever array params are passed to `args`:

```json
{
  "service": {
    "address": "127.0.0.1",
    "checks": [
      {
        "args": [
          "/bin/true",
          "1"
        ],
        "interval": "10s"
      }
    ],
    ...
```