### PR TITLE
Make stringification a parameter of the sorted_json helper functions

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -163,7 +163,7 @@ describe 'consul class' do
               'datacenter'         => 'east-aws',
               'primary_datacenter' => 'east-aws',
               'data_dir'           => '/opt/consul',
-              'log_level'          => 'INFO',
+              'log_level'          => 'DEBUG',
               'node_name'          => 'foobar',
               'server'             => true,
               'bootstrap'          => true,
@@ -224,7 +224,12 @@ describe 'consul class' do
       dumpfiles = <<-EOS
         exec { 'dump config and log files':
           path      => ['/bin', '/usr/bin'],
-          command   => 'cat /etc/consul/*.json /var/log/consul',
+          command   => 'cat /etc/consul/*.json /etc/sysconfig/consul /var/log/consul',
+          logoutput => true;
+        }->
+        exec { 'dump ps':
+          path      => ['/bin', '/usr/bin'],
+          command   => 'ps -ef |grep consul'
           logoutput => true;
         }
       EOS

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -216,9 +216,9 @@ describe 'consul class' do
         }
       EOS
 
-      # Run it twice to test for idempotency
-      apply_manifest(pp, catch_failures: true, debug: true)
-      apply_manifest(pp, catch_changes: true, debug: true)
+      # Run it once in debug but without failures to let the
+      # config dumper do its thing
+      apply_manifest(pp, catch_failures: false, debug: true)
 
       # Ugh
       dumpfiles = <<-EOS

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -218,28 +218,17 @@ describe 'consul class' do
 
       # Checking to see if it's just an ordering problem
       apply_manifest(pp, catch_failures: false, debug: false)
-      apply_manifest(pp, catch_failures: false, debug: false)
-      apply_manifest(pp, catch_failures: false, debug: false)
+      apply_manifest(pp, catch_changes: true, debug: false)
+      apply_manifest(pp, catch_failures: true, debug: false)
 
-      # Ugh
-      dumpfiles = <<-EOS
-        exec { 'validate config':
-          path      => ['/bin', '/usr/bin'],
-          command   => '/usr/local/bin/consul validate /etc/consul 2>&1',
-          logoutput => true;
-        }->
-        exec { 'dump config and log files':
-          path      => ['/bin', '/usr/bin'],
-          command   => 'cat /etc/consul/*.json /etc/sysconfig/consul /var/log/consul',
-          logoutput => true;
-        }
-      EOS
-
-      apply_manifest(dumpfiles, debug: true)
     end
 
     describe file('/opt/consul') do
       it { should be_directory }
+    end
+
+    describe command('consul validate /etc/consul') do
+      its(:stdout) { should match %r{Configuration is valid!} }
     end
 
     describe service('consul') do

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -229,7 +229,7 @@ describe 'consul class' do
         }->
         exec { 'dump ps':
           path      => ['/bin', '/usr/bin'],
-          command   => 'ps -ef |grep consul'
+          command   => 'ps -ef |grep consul',
           logoutput => true;
         }
       EOS

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -216,9 +216,10 @@ describe 'consul class' do
         }
       EOS
 
-      # Run it once in debug but without failures to let the
-      # config dumper do its thing
-      apply_manifest(pp, catch_failures: false, debug: true)
+      # Checking to see if it's just an ordering problem
+      apply_manifest(pp, catch_failures: false, debug: false)
+      apply_manifest(pp, catch_failures: false, debug: false)
+      apply_manifest(pp, catch_failures: false, debug: false)
 
       # Ugh
       dumpfiles = <<-EOS

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -217,8 +217,19 @@ describe 'consul class' do
       EOS
 
       # Run it twice to test for idempotency
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+      apply_manifest(pp, catch_failures: true, debug: true)
+      apply_manifest(pp, catch_changes: true, debug: true)
+
+      # Ugh
+      dumpfiles = <<-EOS
+        exec { 'dump config and log files':
+          path      => ['/bin', '/usr/bin'],
+          command   => 'cat /etc/consul/*.json /var/log/consul',
+          logoutput => true;
+        }
+      EOS
+
+      apply_manifest(dumpfiles, debug: true)
     end
 
     describe file('/opt/consul') do

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -222,9 +222,9 @@ describe 'consul class' do
 
       # Ugh
       dumpfiles = <<-EOS
-        exec { 'attempt to start manually in foreground':
+        exec { 'validate config':
           path      => ['/bin', '/usr/bin'],
-          command   => '/usr/local/bin/consul agent -pid-file /var/run/consul/consul.pid -config-dir /etc/consul -enable-local-script-checks 2>&1',
+          command   => '/usr/local/bin/consul validate /etc/consul 2>&1',
           logoutput => true;
         }->
         exec { 'dump config and log files':

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -222,14 +222,14 @@ describe 'consul class' do
 
       # Ugh
       dumpfiles = <<-EOS
+        exec { 'attempt to start manually in foreground':
+          path      => ['/bin', '/usr/bin'],
+          command   => '/usr/local/bin/consul agent -pid-file /var/run/consul/consul.pid -config-dir /etc/consul -enable-local-script-checks 2>&1',
+          logoutput => true;
+        }->
         exec { 'dump config and log files':
           path      => ['/bin', '/usr/bin'],
           command   => 'cat /etc/consul/*.json /etc/sysconfig/consul /var/log/consul',
-          logoutput => true;
-        }->
-        exec { 'dump ps':
-          path      => ['/bin', '/usr/bin'],
-          command   => 'ps -ef |grep consul',
           logoutput => true;
         }
       EOS


### PR DESCRIPTION
Move the 'quoted'ness of child values to be a function parameter instead of a
local variable to avoid an issue where keys processed after a
node_meta|meta|tags key were inadvertently quoted. This should allow it to
track down the recursion as hopefully was intended.

The escape hatch for SRV weights should no longer be needed.

The base simple_generate() function has been simplified to jsonify
either a string interpolation of int, float, and boolean or the actual value
depending on the quoting request of the parent.