### PR TITLE
Use a filter instead of delete_undef_values()

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -84,7 +84,7 @@ define consul::check (
   }
 
   $check_hash = {
-    check => delete_undef_values($basic_hash),
+    check => $basic_hash.filter |$key, $val| { $val =~ NotUndef },
   }
 
   consul::validate_checks($check_hash[check])

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -105,7 +105,7 @@ define consul::service (
   $basic_hash = $default_config_hash + $service_config_hash
 
   $service_hash = {
-    service => delete_undef_values($basic_hash),
+    service => $basic_hash.filter |$key, $val| { $val =~ NotUndef },
   }
 
   $escaped_id = regsubst($id,'\/','_','G')

--- a/manifests/watch.pp
+++ b/manifests/watch.pp
@@ -136,8 +136,10 @@ define consul::watch (
     }
   }
 
+  $merged_hash = merge($basic_hash, $type_hash)
+
   $watch_hash = {
-    watches => [delete_undef_values(merge($basic_hash, $type_hash))],
+    watches => [$merged_hash.filter |$key, $val| { $val =~ NotUndef }],
   }
 
   file { "${consul::config_dir}/watch_${id}.json":


### PR DESCRIPTION
Use filter instead of delete_undef_values() to keep puppet 6 from
generating json files with 'null' as the value for undefined keys.