### PR TITLE
Removing OpenSuSE from metadata.json to stop triggering broken tests

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -80,13 +80,6 @@
       ]
     },
     {
-      "operatingsystem": "OpenSuSE",
-      "operatingsystemrelease": [
-        "13.1",
-        "13.2"
-      ]
-    },
-    {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
         "11.4",


### PR DESCRIPTION
OpenSuSE 13 only has facterdb entries for facter 2.2-2.4. The
CHECK=test TravisCI tests keep failing due to lack of facter data
for this platform.