### PR TITLE
Allow changing the configuration directory and files owner

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -115,7 +115,7 @@ class consul::config (
 
   file { $consul::config_dir:
     ensure  => 'directory',
-    owner   => $consul::user_real,
+    owner   => $consul::config_owner_real,
     group   => $consul::group_real,
     purge   => $purge,
     recurse => $purge,
@@ -124,7 +124,7 @@ class consul::config (
   file { 'consul config':
     ensure  => file,
     path    => "${consul::config_dir}/${consul::config_name}",
-    owner   => $consul::user_real,
+    owner   => $consul::config_owner_real,
     group   => $consul::group_real,
     mode    => $consul::config_mode,
     content => consul::sorted_json($config_hash, $consul::pretty_config, $consul::pretty_config_indent),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,9 @@
 # [*config_mode*]
 #   Use this to set the JSON config file mode for consul.
 #
+# [*config_owner*]
+#   The user that owns the config_dir directory and its files.
+#
 # [*data_dir_mode*]
 #   Use this to set the data_dir directory mode for consul.
 #
@@ -211,6 +214,7 @@ class consul (
   String[1]                             $config_name                 = 'config.json',
   Hash                                  $config_hash                 = {},
   String[1]                             $config_mode                 = '0664',
+  Optional[String[1]]                   $config_owner                = undef,
   String[1]                             $data_dir_mode               = $consul::params::data_dir_mode,
   String[1]                             $docker_image                = 'consul',
   String[1]                             $download_extension          = 'zip',
@@ -254,13 +258,19 @@ class consul (
   $config_hash_real = deep_merge($config_defaults, $config_hash)
 
   if $install_method == 'docker' {
-    $user_real       = undef
-    $group_real      = undef
-    $init_style_real = 'unmanaged'
+    $user_real         = undef
+    $group_real        = undef
+    $config_owner_real = undef
+    $init_style_real   = 'unmanaged'
   } else {
-    $user_real       = $user
-    $group_real      = $group
-    $init_style_real = $init_style
+    $user_real         = $user
+    $group_real        = $group
+    if $config_owner {
+      $config_owner_real = $config_owner
+    } else {
+      $config_owner_real = $user
+    }
+    $init_style_real   = $init_style
   }
 
   if $config_hash_real['data_dir'] {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -419,6 +419,15 @@ describe 'consul' do
         }
       end
 
+      context "Config with custom config owner" do
+        let(:params) {{
+          :config_owner => 'custom_consul_user',
+          :config_dir => '/etc/custom_consul_dir',
+        }}
+        it { should contain_file('consul config').with(:owner => 'custom_consul_user') }
+        it { should contain_file('/etc/custom_consul_dir').with(:owner => 'custom_consul_user') }
+      end
+
       context 'When consul is reloaded' do
         let(:params) do
           {


### PR DESCRIPTION
This is because it's good practice to keep the service from potentially overwriting its own configuration through some security flaw, meaning having the owner 'root', the group 'consul' and files mode 0640 and directories mode 0750 makes the most sense to keep everyting secure and private.

Note that this works for me because I deploy consul using an rpm where I have set the config directory to have mode 0750, but this is not something this Puppet module will be enforcing. Should a new `config_dir_mode` also be added, defaulting to `undef` to keep backwards compatibility?