### PR TITLE
Service port gets quoted with a puppet 6.10

### DIFF
--- a/lib/puppet/functions/consul/sorted_json.rb
+++ b/lib/puppet/functions/consul/sorted_json.rb
@@ -63,7 +63,7 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
       case obj
         when NilClass, :undef
           'null'
-        when Integer, Float, TrueClass, FalseClass
+        when Float, TrueClass, FalseClass
           if quoted then
             "\"#{obj}\""
           else


### PR DESCRIPTION
Apparently, this is reported issue where one collaborator suggested this change to keep the service check port value unquoted as it's an integer type (not a string).
https://github.com/solarkennedy/puppet-consul/issues/526   

```
consul[12894]: * 'service.port' expected type 'int', got unconvertible type 'string'
```