### PR TITLE
update to support raspberry pi arm arch with Hashicorp splitting out file names

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class consul::params {
     'x86_64', 'x64', 'amd64': { $arch = 'amd64' }
     'i386':                   { $arch = '386'   }
     'aarch64':                { $arch = 'arm64' }
+    'armv7l':                 { $arch = 'armhfv6'}
     /^arm.*/:                 { $arch = 'arm'   }
     default:                  {
       fail("Unsupported kernel architecture: ${facts['architecture']}")


### PR DESCRIPTION
Hashicorp have split out package names on version and architecture, eg: https://releases.hashicorp.com/consul/1.8.0/

the pattern matching in params.pp that points to a *.arm.zip file now fails on non-x86[64] archs due to arm being split out into different zip files one per arch.

