### PR TITLE
add new optional 'datacenters' parameter to consul_policy type

### DIFF
--- a/lib/puppet/type/consul_policy.rb
+++ b/lib/puppet/type/consul_policy.rb
@@ -83,6 +83,14 @@ Puppet::Type.newtype(:consul_policy) do
     end
   end
 
+  newproperty(:datacenters, :array_matching => :all) do
+    desc 'datacenters where the policy is valid within'
+    defaultto []
+    validate do |value|
+      raise ArgumentError, "Datacenter must be a string" if not value.is_a?(String)
+    end
+  end
+
   autorequire(:service) do
     ['consul']
   end

--- a/types/policystruct.pp
+++ b/types/policystruct.pp
@@ -12,4 +12,5 @@ type Consul::PolicyStruct = Struct[{
   port          => Optional[Integer[1, 65535]],
   hostname      => Optional[String[1]],
   api_tries     => Optional[Integer[1]],
+  datacenters   => Optional[Array[String]],
 }]


### PR DESCRIPTION
This PR is to add a new 'datacenters' property to consul_policy type thus allowing to create policies that are valid on specific datacenters only.