### PR TITLE
Add example http service, including a check that demonstrates how to pass headers

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -60,6 +60,28 @@
 #    ],
 #  }
 #
+# @example
+#  consul::service { 'my_https_app':
+#    port                => 443,
+#    tags                => ['web','rails'],
+#    address             => '1.2.3.5',
+#    token               => 'xxxxxxxxxx',
+#    service_config_hash =>  {
+#      'connect' => {
+#        'sidecar_service' => {},
+#      },
+#    },
+#    checks              => [
+#      {
+#        name            => 'HTTPS Request',
+#        http            => 'https://localhost:443',
+#        tls_skip_verify => true,
+#        method          => "GET",
+#        headers         => { "Host" => ["test.example.com"] },
+#      },
+#    ],
+#  }
+#
 define consul::service (
   Optional[String[1]]         $address              = undef,
   Array[Hash]                 $checks               = [],


### PR DESCRIPTION
I thought to put this in the README but it would have been too verbose for what is probably more of an edge case concern, so I added it to the examples documented in `manifests/service.pp` since that's where the README refers you to for "more details"