### PR TITLE
Sysv init script: redirect stderr to logfile

### DIFF
--- a/templates/consul.init.erb
+++ b/templates/consul.init.erb
@@ -54,7 +54,7 @@ start() {
         [ -f $PID_FILE ] && rm $PID_FILE
         daemon --user=<%= scope.lookupvar('consul::user') %> \
             --pidfile="$PID_FILE" \
-            "$CONSUL" agent -pid-file "${PID_FILE}" -config-dir "$CONFIG" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE" &
+            "$CONSUL" agent -pid-file "${PID_FILE}" -config-dir "$CONFIG" <%= scope.lookupvar('consul::extra_options') %> >> "$LOG_FILE" 2>&1 &
         retcode=$?
         echo
         [ $retcode = 0 ] && touch /var/lock/subsys/consul


### PR DESCRIPTION
Consul now checks for all files in the configuration directory. It tries
to load all files. This works for all hcl/json files. Other formats are
ignored and consul prints a message to stderr. It's a legitimate usecase
to store TLS files in the directory. At this point the init script already
returned exit code 0 and people assume the service is up and running.

If started via puppet, no stderr is present to write to and the process
terminates. If we use the init script the start works, because stderr is
present, but consul will leave the terminal open:

```
consul  974195 root    2u   CHR  136,0      0t0       3 /dev/pts/0
consul  974200 consul    2u   CHR     136,0       0t0         3 /dev/pts/0
```

And this will die as soon as we log out and log back in to the terminal

```
consul  974195 root    2u   CHR  136,0      0t0       3  (deleted)/dev/pts/0
consul  974200 consul    2u   CHR     136,0       0t0         3  (deleted)/dev/pts/0
```

The simple fix is to redirect stderr to the same logfile as stdout ¯\_(ツ)_/¯