### PR TITLE
Make stringification a parameter of the sorted_json helper functions

### DIFF
--- a/lib/puppet/functions/consul/sorted_json.rb
+++ b/lib/puppet/functions/consul/sorted_json.rb
@@ -57,18 +57,13 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
   #     }
   #
   def sorted_json(unsorted_hash = {}, pretty = false, indent_len = 4)
-    quoted = false
     # simplify jsonification of standard types
-    simple_generate = lambda do |obj|
+    simple_generate = lambda do |obj, quoted|
       case obj
         when NilClass, :undef
           'null'
         when Integer, Float, TrueClass, FalseClass
-          if quoted then
-            "\"#{obj}\""
-          else
-            "#{obj}"
-          end
+          quoted ? "#{obj}".to_json : obj.to_json
         else
           # Should be a string
           # keep string integers unquoted
@@ -76,40 +71,36 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
       end
     end
 
-    sorted_generate = lambda do |obj|
+    sorted_generate = lambda do |obj, quoted|
       case obj
         when NilClass, :undef, Integer, Float, TrueClass, FalseClass, String
-          return simple_generate.call(obj)
+          return simple_generate.call(obj, quoted)
         when Array
           arrayRet = []
           obj.each do |a|
-            arrayRet.push(sorted_generate.call(a))
+            arrayRet.push(sorted_generate.call(a, quoted))
           end
           return "[" << arrayRet.join(',') << "]";
         when Hash
           ret = []
           obj.keys.sort.each do |k|
-            if k =~ /\A(node_meta|meta|tags|args)\z/ then
-              quoted = true
-            elsif k =~ /\A(weights)\z/ then
-              quoted = false
-            end
-            ret.push(k.to_json << ":" << sorted_generate.call(obj[k]))
+            # Stringify all children of node_meta, meta, and tags
+            (k =~ /\A(node_meta|meta|tags|args)\z/ || quoted) ? quote_children = true : quote_children = false
+            ret.push(k.to_json << ":" << sorted_generate.call(obj[k], quote_children))
           end
-          quoted = false
           return "{" << ret.join(",") << "}";
         else
           raise Exception.new("Unable to handle object of type #{obj.class.name} with value #{obj.inspect}")
       end
     end
 
-    sorted_pretty_generate = lambda do |obj, indent_len=4, level=0|
+    sorted_pretty_generate = lambda do |obj, indent_len=4, level=0, quoted|
       # Indent length
       indent = " " * indent_len
 
       case obj
         when NilClass, :undef, Integer, Float, TrueClass, FalseClass, String
-          return simple_generate.call(obj)
+          return simple_generate.call(obj, quoted)
         when Array
           arrayRet = []
 
@@ -126,7 +117,7 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
           #
           level += 1
           obj.each do |a|
-            arrayRet.push(sorted_pretty_generate.call(a, indent_len, level))
+            arrayRet.push(sorted_pretty_generate.call(a, indent_len, level, quoted))
           end
           level -= 1
 
@@ -138,16 +129,12 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
           # This level works in a similar way to the above
           level += 1
           obj.keys.sort.each do |k|
-            if k =~ /\A(node_meta|meta|tags|args)\z/ then
-              quoted = true
-            elsif k =~ /\A(weights)\z/ then
-              quoted = false
-            end
-            ret.push("#{indent * level}" << k.to_json << ": " << sorted_pretty_generate.call(obj[k], indent_len, level))
+            # Stringify all children of node_meta, meta, and tags
+            (k =~ /\A(node_meta|meta|tags|args)\z/ || quoted) ? quote_children = true : quote_children = false
+            ret.push("#{indent * level}" << k.to_json << ": " << sorted_pretty_generate.call(obj[k], indent_len, level, quote_children))
           end
           level -= 1
 
-          quoted = false
           return "{\n" << ret.join(",\n") << "\n#{indent * level}}";
         else
           raise Exception.new("Unable to handle object of type #{obj.class.name} with value #{obj.inspect}")
@@ -155,9 +142,9 @@ Puppet::Functions.create_function(:'consul::sorted_json') do
     end
 
     if pretty
-      return sorted_pretty_generate.call(unsorted_hash, indent_len) << "\n"
+      return sorted_pretty_generate.call(unsorted_hash, indent_len, false) << "\n"
     else
-      return sorted_generate.call(unsorted_hash)
+      return sorted_generate.call(unsorted_hash, false)
     end
   end
 end


### PR DESCRIPTION
Move the 'quoted'ness of child values to be a function parameter instead of a local variable to avoid an issue where keys processed after a node_meta|meta|tags key were inadvertently quoted. This should allow it to track down the recursion as hopefully was intended.

The escape hatch for SRV weights should no longer be needed.

The base simple_generate() function has been simplified to jsonify either a string interpolation of int, float, and boolean or the actual value depending on the quoting request of the parent.

Fixes #526