### PR TITLE
notify systemd when consul daemon is really started

### DIFF
--- a/templates/consul.systemd.erb
+++ b/templates/consul.systemd.erb
@@ -5,6 +5,12 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+<% if scope.lookupvar('consul::config::config_hash')['retry_join'].nil? or \
+      scope.lookupvar('consul::config::config_hash')['retry_join'].length < 2 -%>
+Type=exec
+<% else -%>
+Type=notify
+<% end -%>
 <% if @allow_binding_to_root_ports == true -%>
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 <% end -%>


### PR DESCRIPTION
Have the following issue on my environment:

puppet runs:
```
# Notice: /Stage[main]/Consul::Run_service/Service[consul]: Triggered 'refresh' from 1 event
# Warning: Cannot retrieve ACL token list: Failed to open TCP connection to localhost:8500 (Address family not supported by protocol - socket(2) for "localhost" port 8500)
```

I suspect that systemd returns to fast and assume that daemon is ready but it is not the case.
Since consul can notify systemd, I change type from simple (default when type is absent) to notify.

External links:
https://www.hashicorp.com/resources/systemd-the-good-parts