### PR TITLE
Add new check options

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -50,37 +50,49 @@
 #   Value in seconds before the http endpoint considers a failing healthcheck
 #   to be "HARD" down.
 #
+# [*success_before_passing*]
+#   Value may be set to become check passing only after a specified number of consecutive
+#   checks return passing
+#
+# [*failures_before_critical*]
+#   Value may be set to become check critical only after a specified number of consecutive
+#   checks return critical
+#
 define consul::check (
-  $ensure     = present,
-  $http       = undef,
-  $id         = $title,
-  $interval   = undef,
-  $notes      = undef,
-  $script     = undef,
-  $args       = undef,
-  $service_id = undef,
-  $status     = undef,
-  $tcp        = undef,
-  $timeout    = undef,
-  $token      = undef,
-  $ttl        = undef,
+  $ensure                   = present,
+  $http                     = undef,
+  $id                       = $title,
+  $interval                 = undef,
+  $notes                    = undef,
+  $script                   = undef,
+  $args                     = undef,
+  $service_id               = undef,
+  $status                   = undef,
+  $tcp                      = undef,
+  $timeout                  = undef,
+  $token                    = undef,
+  $ttl                      = undef,
+  $success_before_passing   = undef,
+  $failures_before_critical = undef,
 ) {
   include consul
 
   $basic_hash = {
-    'id'         => $id,
-    'name'       => $name,
-    'ttl'        => $ttl,
-    'http'       => $http,
-    'script'     => $script,
-    'args'       => $args,
-    'tcp'        => $tcp,
-    'interval'   => $interval,
-    'timeout'    => $timeout,
-    'service_id' => $service_id,
-    'notes'      => $notes,
-    'token'      => $token,
-    'status'     => $status,
+    'id'                       => $id,
+    'name'                     => $name,
+    'ttl'                      => $ttl,
+    'http'                     => $http,
+    'script'                   => $script,
+    'args'                     => $args,
+    'tcp'                      => $tcp,
+    'interval'                 => $interval,
+    'timeout'                  => $timeout,
+    'service_id'               => $service_id,
+    'notes'                    => $notes,
+    'token'                    => $token,
+    'status'                   => $status,
+    'success_before_passing'   => $success_before_passing,
+    'failures_before_critical' => $failures_before_critical,
   }
 
   $check_hash = {


### PR DESCRIPTION
Hello, according to https://www.consul.io/docs/discovery/checks#success-failures-before-passing-critical since Consul 1.7 there are two new check options (success_before_passing, failures_before_critical), but i can't see these in check.pp so I open PR, which can fill missing parameters in check definition.