### PR TITLE
adding the option to setup the upstream HashiCorp repository

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,12 @@ fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     archive: "https://github.com/voxpupuli/puppet-archive.git"
+    hashi_stack: "https://github.com/voxpupuli/puppet-hashi_stack.git"
     systemd: "https://github.com/camptocamp/puppet-systemd.git"
+    apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
+    yum: "https://github.com/voxpupuli/puppet-yum.git"
+    yumrepo_core:
+      repo: "https://github.com/puppetlabs/puppetlabs-yumrepo_core.git"
+      puppet_version: ">= 6.0.0"
   symlinks:
     consul: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,6 +105,9 @@
 # [*manage_group*]
 #   Whether to create/manage the group that should own the consul configuration files.
 #
+# [*manage_repo*]
+#   Configure the upstream HashiCorp repository. Only relevant when $nomad::install_method = 'package'.
+#
 # [*manage_service*]
 #   Whether to manage the consul service.
 #
@@ -217,6 +220,7 @@ class consul (
   String[1]                             $install_method              = 'url',
   Optional[String[1]]                   $join_wan                    = undef,
   Boolean                               $manage_group                = $consul::params::manage_group,
+  Boolean                               $manage_repo                 = $consul::params::manage_repo,
   Boolean                               $manage_service              = true,
   Boolean                               $manage_user                 = $consul::params::manage_user,
   Boolean                               $manage_data_dir             = true,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -65,6 +65,9 @@ class consul::install {
       }
     }
     'package': {
+      if $consul::manage_repo{
+        include hashi_stack::repo
+      }
       package { $consul::package_name:
         ensure => $consul::package_ensure,
         notify => $do_notify_service,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -67,6 +67,7 @@ class consul::install {
     'package': {
       if $consul::manage_repo{
         include hashi_stack::repo
+        Class['hashi_stack::repo'] -> Package[$consul::package_name]
       }
       package { $consul::package_name:
         ensure => $consul::package_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,24 +62,31 @@ class consul::params {
   case $facts['os']['name'] {
     'Ubuntu': {
       $shell = '/usr/sbin/nologin'
+      $manage_repo = true
     }
     'RedHat': {
       $shell = '/sbin/nologin'
+      $manage_repo = true
     }
     'Debian': {
       $shell = '/usr/sbin/nologin'
+      $manage_repo = true
     }
     'Archlinux': {
       $shell = '/sbin/nologin'
+      $manage_repo = false
     }
     'OpenSuSE': {
       $shell = '/usr/sbin/nologin'
+      $manage_repo = false
     }
     /SLE[SD]/: {
       $shell = '/usr/sbin/nologin'
+      $manage_repo = false
     }
     default: {
       $shell = undef
+      $manage_repo = false
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,8 @@
 #
 class consul::params {
 
+  $manage_repo = false
+
   case $facts['architecture'] {
     'x86_64', 'x64', 'amd64': { $arch = 'amd64' }
     'i386':                   { $arch = '386'   }
@@ -62,31 +64,24 @@ class consul::params {
   case $facts['os']['name'] {
     'Ubuntu': {
       $shell = '/usr/sbin/nologin'
-      $manage_repo = true
     }
     'RedHat': {
       $shell = '/sbin/nologin'
-      $manage_repo = true
     }
     'Debian': {
       $shell = '/usr/sbin/nologin'
-      $manage_repo = true
     }
     'Archlinux': {
       $shell = '/sbin/nologin'
-      $manage_repo = false
     }
     'OpenSuSE': {
       $shell = '/usr/sbin/nologin'
-      $manage_repo = false
     }
     /SLE[SD]/: {
       $shell = '/usr/sbin/nologin'
-      $manage_repo = false
     }
     default: {
       $shell = undef
-      $manage_repo = false
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,10 @@
       "version_requirement": ">= 2.0.0 < 5.0.0"
     },
     {
+      "name": "puppet/hashi_stack",
+      "version_requirement": ">=1.0.0 <2.0.0"
+    },
+    {
       "name": "camptocamp/systemd",
       "version_requirement": ">= 1.1.1 < 3.0.0"
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -77,6 +77,47 @@ describe 'consul' do
         it { should_not contain_exec('join consul wan') }
       end
 
+      context "When asked not to manage the repo" do
+        let(:params) {{
+          :manage_repo => false
+        }}
+
+        case facts[:os]['family']
+        when 'Debian'
+          it { should_not contain_apt__source('HashiCorp') }
+        when 'RedHat'
+          it { should_not contain_yumrepo('HashiCorp') }
+        end
+      end
+
+      context "When asked to manage the repo but not to install using package" do
+        let(:params) {{
+          :install_method => 'url',
+          :manage_repo => true
+        }}
+
+        case facts[:os]['family']
+        when 'Debian'
+          it { should_not contain_apt__source('HashiCorp') }
+        when 'RedHat'
+          it { should_not contain_yumrepo('HashiCorp') }
+        end
+      end
+
+      context "When asked to manage the repo and to install as package" do
+        let(:params) {{
+          :install_method => 'package',
+          :manage_repo => true
+        }}
+
+        case facts[:os]['family']
+        when 'Debian'
+          it { should contain_apt__source('HashiCorp') }
+        when 'RedHat'
+          it { should contain_yumrepo('HashiCorp') }
+        end
+      end
+
       context 'When requesting to install via a package with defaults' do
         let(:params) {{
           :install_method => 'package'


### PR DESCRIPTION
HashiCorp now provides (some) upstream packages, this PR implements the managing of the repo