### PR TITLE
OS and Puppet versions update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,63 +4,21 @@ before_install: rm Gemfile.lock || true
 sudo: false
 cache: bundler
 script: bundle exec rake $CHECK
-matrix:
+rvm:
+  - 2.5.7
+jobs:
   fast_finish: true
   include:
-  - rvm: 2.4.4
-    env: PUPPET_VERSION="~> 5.0" CHECK=test
-    bundler_args: --without development
-  - rvm: 2.5.1
-    env: PUPPET_VERSION="~> 5.0" CHECK=test
-    bundler_args: --without development
-  - rvm: 2.5.1
-    env: PUPPET_VERSION="~> 6.0" CHECK=test
-    bundler_args: --without development
-  - rvm: 2.5.1
-    dist: trusty
-    env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=debian9-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    dist: trusty
-    env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=ubuntu1604-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    dist: trusty
-    env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=ubuntu1804-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    dist: trusty
-    env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    dist: trusty
-    env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=centos6-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    dist: trusty
-    env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=debian9-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    dist: trusty
-    env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=ubuntu1604-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    dist: trusty
-    env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=ubuntu1804-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    dist: trusty
-    env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
+    - env: PUPPET_VERSION="~> 6.0" CHECK=test
+      bundler_args: --without development
+    - env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=debian10-64{hypervisor=docker} CHECK=beaker
+      services: docker
+      sudo: required
+    - env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=ubuntu1804-64{hypervisor=docker} CHECK=beaker
+      services: docker
+    - env: BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
+      services: docker
+      sudo: required
 
 deploy:
   provider: puppetforge

--- a/metadata.json
+++ b/metadata.json
@@ -9,67 +9,62 @@
   "issues_url": "https://github.com/solarkennedy/puppet-consul/issues",
   "dependencies": [
     {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
+      "version_requirement": ">= 5.0.0 < 6.0.0"
     },
     {
       "name": "puppet/hashi_stack",
-      "version_requirement": ">=1.0.0 <2.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.1.1 < 3.0.0"
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 6.6.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Amazon",
       "operatingsystemrelease": [
-        "2014.09",
-        "2015.03",
-        "2015.09",
-        "2016.03",
         "2.0"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {
@@ -78,29 +73,28 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "25",
-        "26",
-        "27"
+        "30",
+        "31",
+        "32"
       ]
     },
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "11.4",
-        "12.0"
+        "12",
+        "15"
       ]
     },
     {
       "operatingsystem": "SLED",
       "operatingsystemrelease": [
-        "11.4",
-        "12.0"
+        "12",
+        "15"
       ]
     },
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "10",
         "11",
         "12"
       ]
@@ -109,17 +103,17 @@
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
         "Server 2012 R2",
-        "Server 2016"
+        "Server 2016",
+        "Server 2019"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ],
-  "description": "Configures Consul by Hashicorp",
   "pdk-version": "1.8.0",
   "template-url": "file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git",
   "template-ref": "1.8.0-0-g0d9da00"


### PR DESCRIPTION
This updates the list of supported OSs to those that are not end-of-life and updates the versions of Puppet to those that are currently supported. It also updates dependencies to module versions which include support for Puppet 7.

For reference, a CI overhaul that switches to GitHub Actions will be coming in a follow up PR - thus the minimal modifications to the travis config.