### PR TITLE
enable ssl when protocol is https

### DIFF
--- a/lib/puppet/provider/consul_acl/default.rb
+++ b/lib/puppet/provider/consul_acl/default.rb
@@ -41,6 +41,7 @@ Puppet::Type.type(:consul_acl).provide(
     # but would break for anyone using nonstandard paths
     uri = URI("#{protocol}://#{hostname}:#{port}/v1/acl")
     http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true if uri.instance_of? URI::HTTPS
 
     path = uri.request_uri + "/list?token=#{acl_api_token}"
     req = Net::HTTP::Get.new(path)
@@ -93,6 +94,7 @@ Puppet::Type.type(:consul_acl).provide(
   def put_acl(method, body)
     uri = URI("#{@resource[:protocol]}://#{@resource[:hostname]}:#{@resource[:port]}/v1/acl")
     http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true if uri.instance_of? URI::HTTPS
     acl_api_token = @resource[:acl_api_token]
     path = uri.request_uri + "/#{method}?token=#{acl_api_token}"
     req = Net::HTTP::Put.new(path)

--- a/lib/puppet/provider/consul_key_value/default.rb
+++ b/lib/puppet/provider/consul_key_value/default.rb
@@ -87,6 +87,7 @@ Puppet::Type.type(:consul_key_value).provide(
   def get_path(name)
     uri = URI("#{@resource[:protocol]}://#{@resource[:hostname]}:#{@resource[:port]}/v1/kv/#{name}?dc=#{@resource[:datacenter]}&token=#{@resource[:acl_api_token]}")
     http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true if uri.instance_of? URI::HTTPS
     acl_api_token = @resource[:acl_api_token]
     [uri.request_uri, http]
   end

--- a/lib/puppet/provider/consul_prepared_query/default.rb
+++ b/lib/puppet/provider/consul_prepared_query/default.rb
@@ -39,6 +39,7 @@ Puppet::Type.type(:consul_prepared_query).provide(
     # but would break for anyone using nonstandard paths
     uri = URI("#{protocol}://#{hostname}:#{port}/v1/query")
     http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true if uri.instance_of? URI::HTTPS
 
     path = uri.request_uri + "?token=#{acl_api_token}"
     req = Net::HTTP::Get.new(path)
@@ -81,6 +82,7 @@ Puppet::Type.type(:consul_prepared_query).provide(
     idstr = id ? "/#{id}" : ''
     uri = URI("#{@resource[:protocol]}://#{@resource[:hostname]}:#{@resource[:port]}/v1/query#{idstr}")
     http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true if uri.instance_of? URI::HTTPS
     acl_api_token = @resource[:acl_api_token]
     [uri.request_uri + "?token=#{acl_api_token}", http]
   end

--- a/lib/puppet_x/consul/acl_base.rb
+++ b/lib/puppet_x/consul/acl_base.rb
@@ -9,6 +9,7 @@ module PuppetX::Consul
       def initialize(hostname, port, protocol, api_token = nil)
         @global_uri = URI("#{protocol}://#{hostname}:#{port}/v1/acl")
         @http_client = Net::HTTP.new(@global_uri.host, @global_uri.port)
+        @http_client.use_ssl = true if @global_uri.instance_of? URI::HTTPS
         @api_token = api_token
       end
 


### PR DESCRIPTION
This is a minimal implementation of #519 and fix for #517
This just enables actual ssl use, without adding any extra options for CA's and such.