### PR TITLE
Add special rule format for keyring type policy

### DIFF
--- a/lib/puppet/provider/consul_policy/default.rb
+++ b/lib/puppet/provider/consul_policy/default.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:consul_policy).provide(
     encoded = []
 
     rules.each do |rule|
-      if ['acl', 'operator'].include?(rule['resource'])
+      if ['acl', 'operator', 'keyring'].include?(rule['resource'])
         encoded.push("#{rule['resource']} = \"#{rule['disposition']}\"")
       else
         encoded.push("#{rule['resource']} \"#{rule['segment']}\" {\n  policy = \"#{rule['disposition']}\"\n}")

--- a/lib/puppet/type/consul_policy.rb
+++ b/lib/puppet/type/consul_policy.rb
@@ -33,11 +33,11 @@ Puppet::Type.newtype(:consul_policy) do
       raise ArgumentError, 'Policy rule must be a hash' unless value.is_a?(Hash)
 
       raise ArgumentError, 'Policy rule needs to specify a resource' unless value.key?('resource')
-      raise ArgumentError, 'Policy rule needs to specify a segment' unless value.key?('segment') || ['acl', 'operator'].include?(value['resource'])
+      raise ArgumentError, 'Policy rule needs to specify a segment' unless value.key?('segment') || ['acl', 'operator', 'keyring'].include?(value['resource'])
       raise ArgumentError, 'Policy rule needs to specify a disposition' unless value.key?('disposition')
 
       raise ArgumentError, 'Policy rule resource must be a string' unless value['resource'].is_a?(String)
-      raise ArgumentError, 'Policy rule segment must be a string' unless value['segment'].is_a?(String) || ['acl', 'operator'].include?(value['resource'])
+      raise ArgumentError, 'Policy rule segment must be a string' unless value['segment'].is_a?(String) || ['acl', 'operator', 'keyring'].include?(value['resource'])
       raise ArgumentError, 'Policy rule disposition must be a string' unless value['disposition'].is_a?(String)
     end
 

--- a/spec/unit/puppet/type/consul_policy_spec.rb
+++ b/spec/unit/puppet/type/consul_policy_spec.rb
@@ -96,7 +96,7 @@ describe Puppet::Type.type(:consul_policy) do
     }.to raise_error(Puppet::Error, %r{Policy rule disposition must be a string})
   end
 
-  context 'resource is acl or operator' do
+  context 'resource is acl, operator or keyring' do
     it 'passes if rule segment is missing' do
       expect {
         Puppet::Type.type(:consul_policy).new(
@@ -117,6 +117,17 @@ describe Puppet::Type.type(:consul_policy) do
           rules: [
             {
               'resource' => 'operator',
+                'disposition' => 'read'
+            },
+          ],
+        )
+        Puppet::Type.type(:consul_policy).new(
+          name: 'testing',
+          id: '39c75e12-7f43-0a40-dfba-9aa3fcda08d4',
+          description: 'test description',
+          rules: [
+            {
+              'resource' => 'keyring',
                 'disposition' => 'read'
             },
           ],
@@ -142,7 +153,7 @@ describe Puppet::Type.type(:consul_policy) do
     end
   end
 
-  context 'resource is neither acl nor operator' do
+  context 'resource is neither acl nor operator nor keyring' do
     it 'fails if rule segment is missing' do
       expect {
         Puppet::Type.type(:consul_policy).new(


### PR DESCRIPTION
According to the [official documentation](https://www.consul.io/docs/security/acl/acl-rules#keyring-rules) `keyring` rule has the same format as `operator` and `acl`. 