### PR TITLE
Fix Folder Creation When They Are Not The Defaults

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -113,12 +113,12 @@ class consul::config (
     }
   }
 
-  file { $consul::config_dir:
-    ensure  => 'directory',
-    owner   => $consul::config_owner_real,
-    group   => $consul::group_real,
-    purge   => $purge,
-    recurse => $purge,
+  consul::directory {'Consul Config Directory':
+    directory => $consul::config_dir,
+    owner     => $consul::config_owner_real,
+    group     => $consul::group_real,
+    purge     => $purge,
+    recurse   => $purge,
   }
 
   file { 'consul config':

--- a/manifests/directory.pp
+++ b/manifests/directory.pp
@@ -9,6 +9,26 @@
 #   Define folder that needs to be created.
 #   Defaults to undef
 #
+# [*owner*]
+#   Define the folder's owner
+#   Defaults to undef
+#
+# [*group*]
+#   Define the folder's group
+#   Defaults to undef
+#
+# [*mode*]
+#   Define the folder's permissions
+#   Defaults to undef
+#
+# [*purge*]
+#   Define if the folder should be purged
+#   Defaults to false
+#
+# [*recurse*]
+#   Define if the folder should be recursive
+#   Defaults to false
+#
 define consul::directory (
   $directory = undef,
   $owner     = undef,
@@ -22,14 +42,14 @@ define consul::directory (
   if $directory {
     case $facts['os']['name'] {
       'windows': {
-        exec { "Create ${$directory} Log Folder":
+        exec { "Create ${$directory} Folder":
           path    => $facts['system32'],
           command => "cmd.exe /c mkdir ${$directory}",
           creates => $directory,
         }
       }
       default: {
-        exec { "Create ${$directory} Log Folder":
+        exec { "Create ${$directory} Folder":
           path    => $facts['path'],
           command => "mkdir -p ${$directory}",
           creates => $directory,
@@ -43,7 +63,7 @@ define consul::directory (
       mode    => $mode,
       purge   => $purge,
       recurse => $recurse,
-      require => Exec["Create ${$directory} Log Folder"],
+      require => Exec["Create ${$directory} Folder"],
     }
   }
 }

--- a/manifests/directory.pp
+++ b/manifests/directory.pp
@@ -11,6 +11,11 @@
 #
 define consul::directory (
   $directory = undef,
+  $owner     = undef,
+  $group     = undef,
+  $mode      = undef,
+  $purge     = false,
+  $recurse   = false,
 ) {
   include consul
 
@@ -33,9 +38,11 @@ define consul::directory (
     }
     file { $directory:
       ensure  => 'directory',
-      owner   => $consul::user_real,
-      group   => $consul::group_real,
-      mode    => $consul::data_dir_mode,
+      owner   => $owner,
+      group   => $group,
+      mode    => $mode,
+      purge   => $purge,
+      recurse => $recurse,
       require => Exec["Create ${$directory} Log Folder"],
     }
   }

--- a/manifests/directory.pp
+++ b/manifests/directory.pp
@@ -1,0 +1,42 @@
+# == Define consul::check
+#
+# Sets up a Consul healthcheck
+# http://www.consul.io/docs/agent/checks.html
+#
+# == Parameters
+#
+# [*directory*]
+#   Define folder that needs to be created.
+#   Defaults to undef
+#
+define consul::directory (
+  $directory = undef,
+) {
+  include consul
+
+  if $directory {
+    case $facts['os']['name'] {
+      'windows': {
+        exec { "Create ${$directory} Log Folder":
+          path    => $facts['system32'],
+          command => "cmd.exe /c mkdir ${$directory}",
+          creates => $directory,
+        }
+      }
+      default: {
+        exec { "Create ${$directory} Log Folder":
+          path    => $facts['path'],
+          command => "mkdir -p ${$directory}",
+          creates => $directory,
+        }
+      }
+    }
+    file { $directory:
+      ensure  => 'directory',
+      owner   => $consul::user_real,
+      group   => $consul::group_real,
+      mode    => $consul::data_dir_mode,
+      require => Exec["Create ${$directory} Log Folder"],
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -229,7 +229,7 @@ class consul (
   Array                                 $extra_groups                = [],
   Optional[String[1]]                   $extra_options               = undef,
   String[1]                             $group                       = $consul::params::group,
-  Stdlib::Absolutepath                  $log_file                    = '/var/log/consul',
+  Stdlib::Absolutepath                  $log_file                    = $consul::params::log_file,
   String[1]                             $init_style                  = $consul::params::init_style,
   String[1]                             $install_method              = 'url',
   Optional[String[1]]                   $join_wan                    = undef,
@@ -284,6 +284,12 @@ class consul (
     $data_dir = $config_hash_real['data_dir']
   } else {
     $data_dir = undef
+  }
+
+  if $config_hash_real['log_file'] {
+    $log_dir = regsubst($config_hash_real['log_file'], '[^\\\/]+$', '')
+  } else {
+    $log_dir = undef
   }
 
   if dig($config_hash_real,'ports','http') {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -287,9 +287,7 @@ class consul (
   }
 
   if $config_hash_real['log_file'] {
-    $log_dir = regsubst($config_hash_real['log_file'], '[^\\\/]+$', '')
-  } else {
-    $log_dir = undef
+    $log_file = pick(regsubst($config_hash_real['log_file'], '[^\\\/]+$', ''), $log_file)
   }
 
   if dig($config_hash_real,'ports','http') {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -287,7 +287,9 @@ class consul (
   }
 
   if $config_hash_real['log_file'] {
-    $log_file = pick(regsubst($config_hash_real['log_file'], '[^\\\/]+$', ''), $log_file)
+    $_log_file = pick(regsubst($config_hash_real['log_file'], '[^\\\/]+$', ''), $log_file)
+  } else {
+    $_log_file = $log_file
   }
 
   if dig($config_hash_real,'ports','http') {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,6 +14,24 @@ class consul::install {
     }
   }
 
+  if ($consul::log_dir != $consul::log_file) {
+    file { $consul::log_file:
+      ensure => 'directory',
+      owner  => $consul::user_real,
+      group  => $consul::group_real,
+      mode   => $consul::data_dir_mode,
+    }
+  }
+
+  if $consul::log_dir {
+    file { $consul::log_dir:
+      ensure => 'directory',
+      owner  => $consul::user_real,
+      group  => $consul::group_real,
+      mode   => $consul::data_dir_mode,
+    }
+  }
+
   # only notify if we are installing a new version (work around for switching
   # to archive module)
   if $facts['consul_version'] != $consul::version {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,7 +18,7 @@ class consul::install {
     directory => $consul::_log_file,
   }
 
-  consul::directory {'Consul Log Directory':
+  consul::directory {'Consul Config Directory':
     directory => $consul::config_dir,
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,21 +14,18 @@ class consul::install {
     }
   }
 
-  if ($consul::log_dir != $consul::log_file) {
-    file { $consul::log_file:
-      ensure => 'directory',
-      owner  => $consul::user_real,
-      group  => $consul::group_real,
-      mode   => $consul::data_dir_mode,
-    }
-  }
-
   if $consul::log_dir {
+    exec { 'Create Linux Consul Log Folder':
+      path    => $facts['path'],
+      command => "mkdir -p ${$consul::log_dir}",
+      creates => $consul::log_dir,
+    }
     file { $consul::log_dir:
-      ensure => 'directory',
-      owner  => $consul::user_real,
-      group  => $consul::group_real,
-      mode   => $consul::data_dir_mode,
+      ensure  => 'directory',
+      owner   => $consul::user_real,
+      group   => $consul::group_real,
+      mode    => $consul::data_dir_mode,
+      require => Exec['Create Linux Consul Log Folder'],
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,30 +14,12 @@ class consul::install {
     }
   }
 
-  if $consul::_log_file {
-    case $facts['os']['name'] {
-      'windows': {
-        exec { 'Create Consul Log Folder':
-          path    => $facts['system32'],
-          command => "cmd.exe /c mkdir ${$consul::_log_file}",
-          creates => $consul::_log_file,
-        }
-      }
-      default: {
-        exec { 'Create Consul Log Folder':
-          path    => $facts['path'],
-          command => "mkdir -p ${$consul::_log_file}",
-          creates => $consul::_log_file,
-        }
-      }
-    }
-    file { $consul::_log_file:
-      ensure  => 'directory',
-      owner   => $consul::user_real,
-      group   => $consul::group_real,
-      mode    => $consul::data_dir_mode,
-      require => Exec['Create Consul Log Folder'],
-    }
+  consul::directory {'Consul Log Directory':
+    directory => $consul::_log_file,
+  }
+
+  consul::directory {'Consul Log Directory':
+    directory => $consul::config_dir,
   }
 
   # only notify if we are installing a new version (work around for switching

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,17 +15,28 @@ class consul::install {
   }
 
   if $consul::_log_file {
-    exec { 'Create Linux Consul Log Folder':
-      path    => $facts['path'],
-      command => "mkdir -p ${$consul::_log_file}",
-      creates => $consul::_log_file,
+    case $facts['os']['name'] {
+      'windows': {
+        exec { 'Create Consul Log Folder':
+          path    => $facts['system32'],
+          command => "cmd.exe /c mkdir ${$consul::_log_file}",
+          creates => $consul::_log_file,
+        }
+      }
+      default: {
+        exec { 'Create Consul Log Folder':
+          path    => $facts['path'],
+          command => "mkdir -p ${$consul::_log_file}",
+          creates => $consul::_log_file,
+        }
+      }
     }
     file { $consul::_log_file:
       ensure  => 'directory',
       owner   => $consul::user_real,
       group   => $consul::group_real,
       mode    => $consul::data_dir_mode,
-      require => Exec['Create Linux Consul Log Folder'],
+      require => Exec['Create Consul Log Folder'],
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -49,7 +49,6 @@ class consul::install {
         directory => $consul::bin_dir,
         owner     => $consul::binary_owner,
         group     => $consul::binary_group,
-        mode      => $consul::data_dir_mode,
       }
 
       archive { "${install_path}/consul-${consul::version}.${consul::download_extension}":

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,10 +16,9 @@ class consul::install {
 
   consul::directory {'Consul Log Directory':
     directory => $consul::_log_file,
-  }
-
-  consul::directory {'Consul Config Directory':
-    directory => $consul::config_dir,
+    owner     => $consul::user_real,
+    group     => $consul::group_real,
+    mode      => $consul::data_dir_mode,
   }
 
   # only notify if we are installing a new version (work around for switching

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,13 +14,13 @@ class consul::install {
     }
   }
 
-  if $consul::log_dir {
+  if $consul::_log_file {
     exec { 'Create Linux Consul Log Folder':
       path    => $facts['path'],
-      command => "mkdir -p ${$consul::log_dir}",
-      creates => $consul::log_dir,
+      command => "mkdir -p ${$consul::_log_file}",
+      creates => $consul::_log_file,
     }
-    file { $consul::log_dir:
+    file { $consul::_log_file:
       ensure  => 'directory',
       owner   => $consul::user_real,
       group   => $consul::group_real,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -62,11 +62,19 @@ class consul::install {
         require => Archive["${install_path}/consul-${consul::version}.${consul::download_extension}"],
       }
 
+      consul::directory {'Consul Bin Directory':
+        directory => $consul::bin_dir,
+        owner     => $consul::binary_owner,
+        group     => $consul::binary_group,
+        mode      => $consul::binary_mode,
+        require   => File["${install_path}/consul-${consul::version}/${consul::binary_name}"],
+      }
+
       file { "${consul::bin_dir}/${consul::binary_name}":
         ensure  => link,
         notify  => $do_notify_service,
         target  => "${install_path}/consul-${consul::version}/${consul::binary_name}",
-        require => File["${install_path}/consul-${consul::version}/${consul::binary_name}"],
+        require => Consul::Directory['Consul Bin Directory'],
       }
     }
     'package': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,6 +38,7 @@ class consul::params {
       $config_defaults  = {
         data_dir => 'C:\\ProgramData\\consul',
       }
+      $log_file = 'C:\\ProgramData\\consul\\log'
       $manage_user = false
       $manage_group = false
       $user = 'NT AUTHORITY\NETWORK SERVICE'
@@ -53,6 +54,7 @@ class consul::params {
       $config_defaults  = {
         data_dir => '/opt/consul',
       }
+      $log_file = '/var/log/consul'
       $manage_user = true
       $manage_group = true
       $user = 'consul'

--- a/manifests/windows_service.pp
+++ b/manifests/windows_service.pp
@@ -3,14 +3,10 @@
 # Installs consul windows server
 # == Parameters
 #
-# [*sys32*]
-#   path to system32 folder
-#
 # [*service_name*]
 #   Name of the service
 #
 class consul::windows_service (
-  $sys32 = 'c:\\windows\\system32',
   $service_name = 'Consul'
 ) {
   $executable_file = "${consul::bin_dir}\\${consul::binary_name}"
@@ -18,12 +14,12 @@ class consul::windows_service (
 
   exec { 'create_consul_service':
     command => "sc.exe create ${service_name} ${service_config}",
-    path    => $sys32,
+    path    => $facts['system32'],
     unless  => "sc.exe query ${service_name}",
   }
   exec { 'update_consul_service':
     command     => "sc.exe config ${service_name} ${service_config}",
-    path        => $sys32,
+    path        => $facts['system32'],
     refreshonly => true,
   }
 }


### PR DESCRIPTION
This is a great module and I really like it.

One thing I do when applying this module is I specify my log folder and config folder. Because they are two levels below etc, puppet throughs an error saying it cannot create the parent directory.

This pull request fixes that by sending **log_file**, **config_dir** and **bind_dir** to a defined resource that uses **mkdir** to ensure the parent directories are present.