### PR TITLE
Add special rule format for mesh and peering type policy

### DIFF
--- a/lib/puppet/provider/consul_policy/default.rb
+++ b/lib/puppet/provider/consul_policy/default.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:consul_policy).provide(
     encoded = []
 
     rules.each do |rule|
-      if %w[acl operator keyring].include?(rule['resource'])
+      if %w[acl operator keyring mesh peering].include?(rule['resource'])
         encoded.push("#{rule['resource']} = \"#{rule['disposition']}\"")
       else
         encoded.push("#{rule['resource']} \"#{rule['segment']}\" {\n  policy = \"#{rule['disposition']}\"\n}")

--- a/lib/puppet/type/consul_policy.rb
+++ b/lib/puppet/type/consul_policy.rb
@@ -42,11 +42,11 @@ Puppet::Type.newtype(:consul_policy) do
       raise ArgumentError, 'Policy rule must be a hash' unless value.is_a?(Hash)
 
       raise ArgumentError, 'Policy rule needs to specify a resource' unless value.key?('resource')
-      raise ArgumentError, 'Policy rule needs to specify a segment' unless value.key?('segment') || %w[acl operator keyring].include?(value['resource'])
+      raise ArgumentError, 'Policy rule needs to specify a segment' unless value.key?('segment') || %w[acl operator keyring mesh peering].include?(value['resource'])
       raise ArgumentError, 'Policy rule needs to specify a disposition' unless value.key?('disposition')
 
       raise ArgumentError, 'Policy rule resource must be a string' unless value['resource'].is_a?(String)
-      raise ArgumentError, 'Policy rule segment must be a string' unless value['segment'].is_a?(String) || %w[acl operator keyring].include?(value['resource'])
+      raise ArgumentError, 'Policy rule segment must be a string' unless value['segment'].is_a?(String) || %w[acl operator keyring mesh peering].include?(value['resource'])
       raise ArgumentError, 'Policy rule disposition must be a string' unless value['disposition'].is_a?(String)
     end
 

--- a/spec/unit/puppet/type/consul_policy_spec.rb
+++ b/spec/unit/puppet/type/consul_policy_spec.rb
@@ -102,7 +102,7 @@ describe Puppet::Type.type(:consul_policy) do
     end.to raise_error(Puppet::Error, %r{Policy rule disposition must be a string})
   end
 
-  context 'resource is acl, operator or keyring' do
+  context 'resource is acl, operator, keyring, mesh or peering' do
     it 'passes if rule segment is missing' do
       expect do
         Puppet::Type.type(:consul_policy).new(
@@ -138,6 +138,28 @@ describe Puppet::Type.type(:consul_policy) do
             },
           ]
         )
+        Puppet::Type.type(:consul_policy).new(
+          name: 'testing',
+          id: '39c75e12-7f43-0a40-dfba-9aa3fcda08d4',
+          description: 'test description',
+          rules: [
+            {
+              'resource' => 'mesh',
+              'disposition' => 'read'
+            },
+          ]
+        )
+        Puppet::Type.type(:consul_policy).new(
+          name: 'testing',
+          id: '39c75e12-7f43-0a40-dfba-9aa3fcda08d4',
+          description: 'test description',
+          rules: [
+            {
+              'resource' => 'peering',
+              'disposition' => 'read'
+            },
+          ]
+        )
       end.not_to raise_error
     end
 
@@ -159,7 +181,7 @@ describe Puppet::Type.type(:consul_policy) do
     end
   end
 
-  context 'resource is neither acl nor operator nor keyring' do
+  context 'resource is neither acl nor operator nor keyring nor peering nor mesh' do
     it 'fails if rule segment is missing' do
       expect do
         Puppet::Type.type(:consul_policy).new(


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Consul ACL Rules `mesh` and `peering` type added. 

* mesh - Provides operator-level permissions for resources in the admin partition, such as ingress gateways or mesh proxy defaults.
* peering - Controls access to cluster peerings in the Cluster Peering API.

More details about each resource type: https://developer.hashicorp.com/consul/docs/security/acl/acl-rules#overview
