### PR TITLE
Fix rubocop trailing comma warnings in consul_policy_spec

### DIFF
--- a/spec/unit/puppet/type/consul_policy_spec.rb
+++ b/spec/unit/puppet/type/consul_policy_spec.rb
@@ -145,9 +145,9 @@ describe Puppet::Type.type(:consul_policy) do
           rules: [
             {
               'resource' => 'mesh',
-              'disposition' => 'read'
+              'disposition' => 'read',
             },
-          ]
+          ],
         )
         Puppet::Type.type(:consul_policy).new(
           name: 'testing',
@@ -156,9 +156,9 @@ describe Puppet::Type.type(:consul_policy) do
           rules: [
             {
               'resource' => 'peering',
-              'disposition' => 'read'
+              'disposition' => 'read',
             },
-          ]
+          ],
         )
       end.not_to raise_error
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--

-->

#### This Pull Request (PR) fixes the following issues
<!--

-->
  Fixes the trailing comma lint warnings introduced in #653.
  Added missing trailing commas in multiline hash literals and method calls
  as required by Style/TrailingCommaInHashLiteral and Style/TrailingCommaInArguments.
